### PR TITLE
Fix HT32_SERIAL_USE_USART0 compile warning

### DIFF
--- a/cfg/mcuconf.h
+++ b/cfg/mcuconf.h
@@ -53,6 +53,7 @@
 #define HT32_GPT_USE_BFTM0                  TRUE
 #define HT32_GPT_BFTM0_IRQ_PRIORITY         4
 
+#define HT32_SERIAL_USE_USART0              FALSE
 #define HT32_SERIAL_USE_USART1              TRUE
 #define HT32_USART1_IRQ_PRIORITY            3
 


### PR DESCRIPTION
Define HT32_SERIAL_USE_USART0 as false.

Clears compile warnings.