### PR TITLE
Lighting profiles as function pointers

### DIFF
--- a/main.c
+++ b/main.c
@@ -180,7 +180,7 @@ void ledSet(){
   size_t bytesRead;
   bytesRead = sdReadTimeout(&SD1, commandBuffer, 4, 10000);
 
-  if(bytesRead > 4){
+  if(bytesRead >= 4){
       if(commandBuffer[0] < NUM_ROW || commandBuffer[1] < NUM_COLUMN){
           setKeyColor(&ledColors[commandBuffer[0] * NUM_COLUMN + commandBuffer[1]], ((uint16_t)commandBuffer[3] << 8 | commandBuffer[2]));
       }

--- a/main.c
+++ b/main.c
@@ -25,12 +25,12 @@
 
 static void columnCallback(GPTDriver* driver);
 static void animationCallback(GPTDriver* driver);
-void executeMsg(msg_t msg);
-void switchProfile(void);
-void executeProfile(void);
-void disableLeds(void);
-void ledSet(void);
-void ledSetRow(void);
+static void executeMsg(msg_t msg);
+static void switchProfile(void);
+static void executeProfile(void);
+static void disableLeds(void);
+static void ledSet(void);
+static void ledSetRow(void);
 
 
 ioline_t ledColumns[NUM_COLUMN] = {

--- a/main.c
+++ b/main.c
@@ -30,7 +30,7 @@ void switchProfile(void);
 void executeProfile(void);
 void disableLeds(void);
 void ledSet(void);
-void ledRowSet(void);
+void ledSetRow(void);
 
 
 ioline_t ledColumns[NUM_COLUMN] = {

--- a/main.c
+++ b/main.c
@@ -67,25 +67,15 @@ ioline_t ledRows[NUM_ROW * 3] = {
 
 #define LEN(a) (sizeof(a)/sizeof(*a))
 
-// An array of basic colors used accross different lighting profiles
-// static const uint32_t colorPalette[] = {0xFF0000, 0xF0F00, 0x00F00, 0x00F0F, 0x0000F, 0xF000F, 0x50F0F};
-static const uint32_t colorPalette[] = {0x9c0000, 0x9c9900, 0x1f9c00, 0x00979c, 0x003e9c, 0x39009c, 0x9c008f};
 
-// The total number of lighting profiles. Each color in the color palette is a static profile of its own + custom ones 
-static const uint16_t NUM_LIGHTING_PROFILES = LEN(colorPalette) + 8;
-
-// Indicates the ID of the current lighting profile
-static uint8_t lightingProfile = 0;
-
-// Column offset for rainbow animation
-static uint8_t colAnimOffset = 0;
-
-// Variables for Breathing and Spectrum Effect
-static uint8_t value = 180;
-static int direction = -1;
-
-// Variables for Rainbow Flow
-static uint8_t values[NUM_COLUMN];
+/*
+ * Active profiles
+ * Add profiles from source/profiles.h in the profile array
+ */
+typedef void (*profile)( led_t* );
+profile profiles[6] = {red, green, blue, rainbowHorizontal, rainbowVertical, animatedRainbow};
+static uint8_t currentProfile = 0;
+static uint8_t amountOfProfiles = sizeof(profiles)/sizeof(profile);
 
 led_t ledColors[70];
 static uint32_t currentColumn = 0;

--- a/main.c
+++ b/main.c
@@ -156,7 +156,7 @@ void switchProfile(){
  */
 void executeProfile(){
   chSysLock();
-  profiles[currentProfile](currentKeyLedColors);
+  profiles[currentProfile](ledColors);
   palSetLine(LINE_LED_PWR);
   chSysUnlock();
 }
@@ -193,71 +193,10 @@ inline uint8_t min(uint8_t a, uint8_t b){
 
 // Update lighting table as per animation
 void animationCallback(GPTDriver* _driver){
-  
-  // Update lighting according to the current lighting profile
-  switch(lightingProfile){
-
-    // Breathing
-    case LEN(colorPalette) + 4:
-      gptChangeInterval(_driver, ANIMATION_TIMER_FREQUENCY/30);
-      setAllKeysColorHSV(ledColors, 85, 255, value);
-      if(value >= 180){
-        direction = -1;
-      }else if(value <= 0){
-        direction = 1;
-      }
-      value += direction;
-      break;
-
-    // Spectrum
-    case LEN(colorPalette) + 5:
-      gptChangeInterval(_driver, ANIMATION_TIMER_FREQUENCY/15);
-      setAllKeysColorHSV(ledColors, value, 255, 125);
-      if(value >= 179){
-        direction = -1;
-      }else if(value <= 1){
-        direction = 1;
-      }
-      value += direction;
-      break;
-
-    // Rainbow Flow
-    case LEN(colorPalette) + 6:
-      gptChangeInterval(_driver, ANIMATION_TIMER_FREQUENCY/30);
-      for(int i = 0; i < NUM_COLUMN; i++){
-        setColumnColorHSV(ledColors, i, values[i], 255, 125);
-        if(values[i] == 179){
-          values[i] = 240;
-        }
-        values[i]++;
-      }
-      break;
-
-    // Rainbow Waterfall
-    case LEN(colorPalette) + 7:
-      gptChangeInterval(_driver, ANIMATION_TIMER_FREQUENCY/20);
-      for(int i = 0; i < NUM_ROW; i++){
-        setRowColorHSV(ledColors, i, values[i], 255, 125);
-        if(values[i] == 179){
-          values[i] = 240;
-        }
-        values[i]++;
-      }
-      break;
-    
-    // Vertical Rainbow Profile
-    case 0:
-      // Set refresh rate for this animation
-      gptChangeInterval(_driver, ANIMATION_TIMER_FREQUENCY/5);
-      // Update led colors
-      for (uint16_t i=0; i<NUM_COLUMN; ++i){
-        for (uint16_t j=0; j<NUM_ROW; ++j){
-          setKeyColor(&ledColors[j*NUM_COLUMN+i], colorPalette[(i + colAnimOffset)%LEN(colorPalette)]);
-        }     
-      }
-      colAnimOffset = (colAnimOffset + 1)%LEN(colorPalette);
-      break;
-
+  profile currentFunction = profiles[currentProfile];
+  if(currentFunction == animatedRainbow){
+      gptChangeInterval(_driver, ANIMATION_TIMER_FREQUENCY/7);
+      currentFunction(ledColors);
   }
 }
 

--- a/main.c
+++ b/main.c
@@ -73,7 +73,6 @@ ioline_t ledRows[NUM_ROW * 3] = {
 
 #define LEN(a) (sizeof(a)/sizeof(*a))
 
-
 /*
  * Active profiles
  * Add profiles from source/profiles.h in the profile array
@@ -169,6 +168,9 @@ void disableLeds(){
   palClearLine(LINE_LED_PWR);
 }
 
+/*
+ * Set a led based on qmk communication
+ */
 void ledSet(){
   bytesRead = sdReadTimeout(&SD1, commandBuffer, 4, 10000);
   if (bytesRead < 4)
@@ -178,6 +180,9 @@ void ledSet(){
   setKeyColor(&ledColors[commandBuffer[0] * NUM_COLUMN + commandBuffer[1]], ((uint16_t)commandBuffer[3] << 8 | commandBuffer[2]));
 }
 
+/*
+ * Set a row of leds based on qmk communication
+ */
 void ledSetRow(){
   bytesRead = sdReadTimeout(&SD1, commandBuffer, sizeof(uint16_t) * NUM_COLUMN + 1, 1000);
   if (bytesRead < sizeof(uint16_t) * NUM_COLUMN + 1)
@@ -191,7 +196,9 @@ inline uint8_t min(uint8_t a, uint8_t b){
   return a<=b?a:b;
 }
 
-// Update lighting table as per animation
+/*
+ * Update lighting table as per animation
+ */
 void animationCallback(GPTDriver* _driver){
   profile currentFunction = profiles[currentProfile];
   if(currentFunction == animatedRainbow){

--- a/main.c
+++ b/main.c
@@ -20,6 +20,7 @@
 #include "string.h"
 #include "ap2_qmk_led.h"
 #include "light_utils.h"
+#include "profiles.h"
 #include "miniFastLED.h"
 
 static void columnCallback(GPTDriver* driver);
@@ -78,7 +79,11 @@ ioline_t ledRows[NUM_ROW * 3] = {
  * Add profiles from source/profiles.h in the profile array
  */
 typedef void (*profile)( led_t* );
-profile profiles[6] = {red, green, blue, rainbowHorizontal, rainbowVertical, animatedRainbow};
+profile profiles[9] = {
+  red, green, blue, rainbowHorizontal, rainbowVertical, 
+  animatedRainbowVertical, animatedRainbowWaterfall, 
+  animatedBreathing, animatedSpectrum
+};
 static uint8_t currentProfile = 0;
 static uint8_t amountOfProfiles = sizeof(profiles)/sizeof(profile);
 
@@ -172,6 +177,7 @@ void disableLeds(){
  * Set a led based on qmk communication
  */
 void ledSet(){
+  size_t bytesRead;
   bytesRead = sdReadTimeout(&SD1, commandBuffer, 4, 10000);
   if (bytesRead < 4)
     continue;
@@ -184,6 +190,7 @@ void ledSet(){
  * Set a row of leds based on qmk communication
  */
 void ledSetRow(){
+  size_t bytesRead;
   bytesRead = sdReadTimeout(&SD1, commandBuffer, sizeof(uint16_t) * NUM_COLUMN + 1, 1000);
   if (bytesRead < sizeof(uint16_t) * NUM_COLUMN + 1)
     continue;
@@ -201,9 +208,21 @@ inline uint8_t min(uint8_t a, uint8_t b){
  */
 void animationCallback(GPTDriver* _driver){
   profile currentFunction = profiles[currentProfile];
-  if(currentFunction == animatedRainbow){
-      gptChangeInterval(_driver, ANIMATION_TIMER_FREQUENCY/7);
-      currentFunction(ledColors);
+  if(currentFunction == animatedRainbowVertical){
+    gptChangeInterval(_driver, ANIMATION_TIMER_FREQUENCY/5);
+    currentFunction(ledColors);
+  }else if(currentFunction == animatedRainbowWaterfall){
+    gptChangeInterval(_driver, ANIMATION_TIMER_FREQUENCY/20);
+    currentFunction(ledColors);
+  }else if(currentFunction == animatedRainbowFlow){
+    gptChangeInterval(_driver, ANIMATION_TIMER_FREQUENCY/30);
+    currentFunction(ledColors);
+  }else if(currentFunction == animatedSpectrum){
+    gptChangeInterval(_driver, ANIMATION_TIMER_FREQUENCY/15);
+    currentFunction(ledColors);
+  }else if(currentFunction == animatedBreathing){
+    gptChangeInterval(_driver, ANIMATION_TIMER_FREQUENCY/30);
+    currentFunction(ledColors);
   }
 }
 

--- a/main.c
+++ b/main.c
@@ -179,11 +179,12 @@ void disableLeds(){
 void ledSet(){
   size_t bytesRead;
   bytesRead = sdReadTimeout(&SD1, commandBuffer, 4, 10000);
-  if (bytesRead < 4)
-    continue;
-  if (commandBuffer[0] >= NUM_ROW || commandBuffer[1] >= NUM_COLUMN)
-    continue;
-  setKeyColor(&ledColors[commandBuffer[0] * NUM_COLUMN + commandBuffer[1]], ((uint16_t)commandBuffer[3] << 8 | commandBuffer[2]));
+
+  if(bytesRead > 4){
+      if(commandBuffer[0] < NUM_ROW || commandBuffer[1] < NUM_COLUMN){
+          setKeyColor(&ledColors[commandBuffer[0] * NUM_COLUMN + commandBuffer[1]], ((uint16_t)commandBuffer[3] << 8 | commandBuffer[2]));
+      }
+  }
 }
 
 /*
@@ -192,11 +193,11 @@ void ledSet(){
 void ledSetRow(){
   size_t bytesRead;
   bytesRead = sdReadTimeout(&SD1, commandBuffer, sizeof(uint16_t) * NUM_COLUMN + 1, 1000);
-  if (bytesRead < sizeof(uint16_t) * NUM_COLUMN + 1)
-    continue;
-  if (commandBuffer[0] >= NUM_ROW)
-    continue;
-  memcpy(&ledColors[commandBuffer[0] * NUM_COLUMN],&commandBuffer[1], sizeof(uint16_t) * NUM_COLUMN); 
+  if(bytesRead >= sizeof(uint16_t) * NUM_COLUMN + 1){
+    if(commandBuffer[0] < NUM_ROW){
+      memcpy(&ledColors[commandBuffer[0] * NUM_COLUMN],&commandBuffer[1], sizeof(uint16_t) * NUM_COLUMN); 
+    }
+  }
 }
 
 inline uint8_t min(uint8_t a, uint8_t b){

--- a/source/profiles.c
+++ b/source/profiles.c
@@ -1,107 +1,107 @@
 #include "profiles.h"
+#include "miniFastLED.h"
 
 // An array of basic colors used accross different lighting profiles
 // static const uint32_t colorPalette[] = {0xFF0000, 0xF0F00, 0x00F00, 0x00F0F, 0x0000F, 0xF000F, 0x50F0F};
 static const uint32_t colorPalette[] = {
-    0x9c0000, 0x9c9900, 0x1f9c00, 
-    0x00979c, 0x003e9c, 0x39009c, 
-    0x9c008f
+  0x9c0000, 0x9c9900, 0x1f9c00, 
+  0x00979c, 0x003e9c, 0x39009c, 
+  0x9c008f
 };
-
-// Variables for Breathing and Spectrum Effect
-static uint8_t value = 180;
-static int direction = -1;
-
-// Variables for Rainbow Flow
-static uint8_t values[NUM_COLUMN];
 
 #define LEN(a) (sizeof(a)/sizeof(*a))
 
 void red(led_t* currentKeyLedColors){
-    setAllKeysColor(currentKeyLedColors, 0xFF0000);
+  setAllKeysColor(currentKeyLedColors, 0xFF0000);
 }
 
 void green(led_t* currentKeyLedColors){
-    setAllKeysColor(currentKeyLedColors, 0x00FF00);
+  setAllKeysColor(currentKeyLedColors, 0x00FF00);
 }
 
 void blue(led_t* currentKeyLedColors){
-    setAllKeysColor(currentKeyLedColors, 0x0000FF);
+  setAllKeysColor(currentKeyLedColors, 0x0000FF);
 }
 
 void miamiNights(led_t* currentKeyLedColors){
-    setAllKeysColor(currentKeyLedColors, 0x00979c);
-    setModKeysColor(currentKeyLedColors, 0x9c008f);
+  setAllKeysColor(currentKeyLedColors, 0x00979c);
+  setModKeysColor(currentKeyLedColors, 0x9c008f);
 }
 
 void rainbowHorizontal(led_t* currentKeyLedColors){
-    for (uint8_t i=0; i<NUM_ROW; ++i){
-        setRowKeysColor(currentKeyLedColors, i, colorPalette[i%LEN(colorPalette)]); 
-    }
+  for (uint16_t i=0; i<NUM_ROW; ++i){
+    for (uint16_t j=0; j<NUM_COLUMN; ++j){
+      setKeyColor(&currentKeyLedColors[i*NUM_COLUMN+j], colorPalette[i%LEN(colorPalette)]);
+    }     
+  }
 }
 
 void rainbowVertical(led_t* currentKeyLedColors){
-    for (uint8_t i=0; i<NUM_COLUMN; ++i){
-        setColumnKeysColor(currentKeyLedColors, i, colorPalette[i%LEN(colorPalette)]);
-    }
+  for (uint16_t i=0; i<NUM_COLUMN; ++i){
+    for (uint16_t j=0; j<NUM_ROW; ++j){
+      setKeyColor(&currentKeyLedColors[j*NUM_COLUMN+i], colorPalette[i%LEN(colorPalette)]);
+    }     
+  }
 }
 
 static uint8_t colAnimOffset = 0;
 void animatedRainbowVertical(led_t* currentKeyLedColors){
-    for (uint8_t i=0; i<NUM_COLUMN; ++i){
-        setColumnKeysColor(currentKeyLedColors, i, colorPalette[(i + colAnimOffset)%LEN(colorPalette)]);
-    }
-    colAnimOffset = (colAnimOffset + 1)%LEN(colorPalette);
+  for (uint16_t i=0; i<NUM_COLUMN; ++i){
+    for (uint16_t j=0; j<NUM_ROW; ++j){
+      setKeyColor(&currentKeyLedColors[j*NUM_COLUMN+i], colorPalette[(i + colAnimOffset)%LEN(colorPalette)]);
+    }     
+  }
+  colAnimOffset = (colAnimOffset + 1)%LEN(colorPalette);
 }
 
 static uint8_t flowValue[NUM_COLUMN] = {
-    0, 11, 22, 33, 44, 55, 66, 77,
-    88, 99, 110, 121, 132, 143
+  0, 11, 22, 33, 44, 55, 66, 77,
+  88, 99, 110, 121, 132, 143
 };
 void animatedRainbowFlow(led_t* currentKeyLedColors){
-    for(int i = 0; i < NUM_COLUMN; i++){
-        setColumnColorHSV(currentKeyLedColors, i, values[i], 255, 125);
-        if(values[i] == 179){
-            values[i] = 240;
-        }
-        values[i]++;
+  for(int i = 0; i < NUM_COLUMN; i++){
+    setColumnColorHSV(currentKeyLedColors, i, flowValue[i], 255, 125);
+    if(flowValue[i] == 179){
+      flowValue[i] = 240;
     }
+    flowValue[i]++;
+  }
 }
 
 static uint8_t waterfallValue[NUM_COLUMN] = {
-    0, 10, 20, 30, 40, 50, 60, 70,
-    80, 90, 100, 110, 120, 130
+  0, 10, 20, 30, 40, 50, 60, 70,
+  80, 90, 100, 110, 120, 130
 };
 void animatedRainbowWaterfall(led_t* currentKeyLedColors){
-    for(int i = 0; i < NUM_ROW; i++){
-        setRowColorHSV(currentKeyLedColors, i, values[i], 255, 125);
-        if(values[i] == 179){
-            values[i] = 240;
-        }
-        values[i]++;
+  for(int i = 0; i < NUM_ROW; i++){
+    setRowColorHSV(currentKeyLedColors, i, waterfallValue[i], 255, 125);
+    if(waterfallValue[i] == 179){
+      waterfallValue[i] = 240;
     }
+    waterfallValue[i]++;
+  }
 }
 
 static uint8_t breathingValue = 180;
 static int breathingDirection = -1;
 void animatedBreathing(led_t* currentKeyLedColors){
-    setAllKeysColorHSV(currentKeyLedColors, 85, 255, value);
-    if(breathingValue >= 180){
-        breathingDirection = -1;
-    }else if(breathingValue <= 0){
-        breathingDirection = 1;
-    }
-    breathingValue += breathingDirection;
+  setAllKeysColorHSV(currentKeyLedColors, 85, 255, breathingValue);
+  if(breathingValue >= 180){
+    breathingDirection = -1;
+  }else if(breathingValue <= 0){
+    breathingDirection = 1;
+  }
+  breathingValue += breathingDirection;
 }
 
 static uint8_t spectrumValue = 2;
 static int spectrumDirection = 1;
 void animatedSpectrum(led_t* currentKeyLedColors){
-    setAllKeysColorHSV(currentKeyLedColors, value, 255, 125);
-    if(spectrumValue >= 179){
-        spectrumDirection = -1;
-    }else if(spectrumValue <= 1){
-        spectrumDirection = 1;
-    }
-    spectrumValue += spectrumDirection;
+  setAllKeysColorHSV(currentKeyLedColors, spectrumValue, 255, 125);
+  if(spectrumValue >= 179){
+    spectrumDirection = -1;
+  }else if(spectrumValue <= 1){
+    spectrumDirection = 1;
+  }
+  spectrumValue += spectrumDirection;
 }

--- a/source/profiles.c
+++ b/source/profiles.c
@@ -1,0 +1,107 @@
+#include "profiles.h"
+
+// An array of basic colors used accross different lighting profiles
+// static const uint32_t colorPalette[] = {0xFF0000, 0xF0F00, 0x00F00, 0x00F0F, 0x0000F, 0xF000F, 0x50F0F};
+static const uint32_t colorPalette[] = {
+    0x9c0000, 0x9c9900, 0x1f9c00, 
+    0x00979c, 0x003e9c, 0x39009c, 
+    0x9c008f
+};
+
+// Variables for Breathing and Spectrum Effect
+static uint8_t value = 180;
+static int direction = -1;
+
+// Variables for Rainbow Flow
+static uint8_t values[NUM_COLUMN];
+
+#define LEN(a) (sizeof(a)/sizeof(*a))
+
+void red(led_t* currentKeyLedColors){
+    setAllKeysColor(currentKeyLedColors, 0xFF0000);
+}
+
+void green(led_t* currentKeyLedColors){
+    setAllKeysColor(currentKeyLedColors, 0x00FF00);
+}
+
+void blue(led_t* currentKeyLedColors){
+    setAllKeysColor(currentKeyLedColors, 0x0000FF);
+}
+
+void miamiNights(led_t* currentKeyLedColors){
+    setAllKeysColor(currentKeyLedColors, 0x00979c);
+    setModKeysColor(currentKeyLedColors, 0x9c008f);
+}
+
+void rainbowHorizontal(led_t* currentKeyLedColors){
+    for (uint8_t i=0; i<NUM_ROW; ++i){
+        setRowKeysColor(currentKeyLedColors, i, colorPalette[i%LEN(colorPalette)]); 
+    }
+}
+
+void rainbowVertical(led_t* currentKeyLedColors){
+    for (uint8_t i=0; i<NUM_COLUMN; ++i){
+        setColumnKeysColor(currentKeyLedColors, i, colorPalette[i%LEN(colorPalette)]);
+    }
+}
+
+static uint8_t colAnimOffset = 0;
+void animatedRainbowVertical(led_t* currentKeyLedColors){
+    for (uint8_t i=0; i<NUM_COLUMN; ++i){
+        setColumnKeysColor(currentKeyLedColors, i, colorPalette[(i + colAnimOffset)%LEN(colorPalette)]);
+    }
+    colAnimOffset = (colAnimOffset + 1)%LEN(colorPalette);
+}
+
+static uint8_t flowValue[NUM_COLUMN] = {
+    0, 11, 22, 33, 44, 55, 66, 77,
+    88, 99, 110, 121, 132, 143
+};
+void animatedRainbowFlow(led_t* currentKeyLedColors){
+    for(int i = 0; i < NUM_COLUMN; i++){
+        setColumnColorHSV(currentKeyLedColors, i, values[i], 255, 125);
+        if(values[i] == 179){
+            values[i] = 240;
+        }
+        values[i]++;
+    }
+}
+
+static uint8_t waterfallValue[NUM_COLUMN] = {
+    0, 10, 20, 30, 40, 50, 60, 70,
+    80, 90, 100, 110, 120, 130
+};
+void animatedRainbowWaterfall(led_t* currentKeyLedColors){
+    for(int i = 0; i < NUM_ROW; i++){
+        setRowColorHSV(currentKeyLedColors, i, values[i], 255, 125);
+        if(values[i] == 179){
+            values[i] = 240;
+        }
+        values[i]++;
+    }
+}
+
+static uint8_t breathingValue = 180;
+static int breathingDirection = -1;
+void animatedBreathing(led_t* currentKeyLedColors){
+    setAllKeysColorHSV(currentKeyLedColors, 85, 255, value);
+    if(breathingValue >= 180){
+        breathingDirection = -1;
+    }else if(breathingValue <= 0){
+        breathingDirection = 1;
+    }
+    breathingValue += breathingDirection;
+}
+
+static uint8_t spectrumValue = 2;
+static int spectrumDirection = 1;
+void animatedSpectrum(led_t* currentKeyLedColors){
+    setAllKeysColorHSV(currentKeyLedColors, value, 255, 125);
+    if(spectrumValue >= 179){
+        spectrumDirection = -1;
+    }else if(spectrumValue <= 1){
+        spectrumDirection = 1;
+    }
+    spectrumValue += spectrumDirection;
+}

--- a/source/profiles.h
+++ b/source/profiles.h
@@ -1,0 +1,20 @@
+#include "light_utils.h"
+
+/*
+ * STATIC
+ */
+void red(led_t* currentKeyLedColors);
+void green(led_t* currentKeyLedColors);
+void blue(led_t* currentKeyLedColors);
+void rainbowHorizontal(led_t* currentKeyLedColors);
+void rainbowVertical(led_t* currentKeyLedColors);
+void miamiNights(led_t* currentKeyLedColors);
+
+/*
+ * ANIMATED
+ */
+void animatedRainbowVertical(led_t* currentKeyLedColors);
+void animatedRainbowFlow(led_t* currentKeyLedColors);
+void animatedRainbowWaterfall(led_t* currentKeyLedColors);
+void animatedBreathing(led_t* currentKeyLedColors);
+void animatedSpectrum(led_t* currentKeyLedColors);


### PR DESCRIPTION
**Changes:**
- Moved profiles to their own file
- Using an array of profile function pointers
- Split Thread 1 to multiple functions (program flow)
- Given led set code their own functions

**Improvements:**
- Easy to set wanted functions in an array by name
- Easy to create new functions
- Order lighting profiles (No longer restricted by a huge switch statement)
- No longer needed to check what the active function is (Only the place in the array)
- Less code in a single function (Thread 1)
- Easier to understand what the program flow is
- Deduplication of profile code (animation profile setup and execution)

**What can be improved?:**
- Animation callback needs to use if else statements (AFAIK function pointers can't be in a switch statement)

**Tested**:
- Using C18 version
- All profiles seem to work normally
- ledSet works (CAPS)

I tried my best following the same style. The .bin file changed from 7.4K to 7.2K.

