### PR TITLE
Restore default led behavior on keymaps

### DIFF
--- a/main.c
+++ b/main.c
@@ -152,7 +152,7 @@ void executeMsg(msg_t msg){
       executeProfile();
       break;
     case CMD_LED_PREV_PROFILE:
-      currentProfile = (currentProfile-1u)%amountOfProfiles;
+      currentProfile = (currentProfile+(amountOfProfiles-1u))%amountOfProfiles;
       executeProfile();
       break;
     case CMD_LED_GET_PROFILE:


### PR DESCRIPTION
The bidir PR changed the behavior of a few commands, changing the existing behavior of the lighting keys.

With this, enable/disable are decoupled from next/prev. 
Also a underflow introduced to the prev profile command is fixed.