### PR TITLE
Introduce new make targets to improve workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,12 @@
 
 # Compiler options here.
 ifeq ($(USE_OPT),)
-  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
-endif
-
-ifeq ($(MODEL), C18)
-  USE_OPT += -DC18
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16 -Wno-cpp -DHAL_USE_COMMUNITY
 endif
 
 # C specific options here (added to USE_OPT).
 ifeq ($(USE_COPT),)
-  USE_COPT = 
+  USE_COPT =
 endif
 
 # C++ specific options here (added to USE_OPT).
@@ -29,7 +25,7 @@ endif
 
 # Linker extra options here.
 ifeq ($(USE_LDOPT),)
-  USE_LDOPT = 
+  USE_LDOPT =
 endif
 
 # Enable this if you want link time optimizations (LTO).
@@ -85,9 +81,6 @@ endif
 ##############################################################################
 # Project, target, sources and paths
 #
-
-# Define project name here
-PROJECT = annepro2-shine
 
 # Target settings.
 MCU  = cortex-m0plus
@@ -164,6 +157,27 @@ ULIBDIR =
 
 # List all user libraries here
 ULIBS =
+
+ifeq "$(strip $(filter C15,$(MAKECMDGOALS)))" "C15"
+BUILDDIR = build/C15
+PROJECT = annepro2-shine-C15
+endif
+ifeq "$(strip $(filter C18,$(MAKECMDGOALS)))" "C18"
+BUILDDIR = build/C18
+PROJECT = annepro2-shine-C18
+endif
+
+.PHONY: default
+default:
+	$(MAKE) C18
+	$(MAKE) C15
+
+C15: all
+	@cp $(BUILDDIR)/$(PROJECT).bin build/$(PROJECT).bin
+
+C18: CFLAGS += -DC18
+C18: all
+	@cp $(BUILDDIR)/$(PROJECT).bin build/$(PROJECT).bin
 
 #
 # End of user section

--- a/cfg/halconf_community.h
+++ b/cfg/halconf_community.h
@@ -1,0 +1,4 @@
+// this file exists just to get rid of a warning
+#ifndef HALCONF_COMMUNITY_H
+#define HALCONF_COMMUNITY_H
+#endif

--- a/readme.md
+++ b/readme.md
@@ -10,16 +10,21 @@ but it provides the flexibility for creating custom effects.
 
 **Warning: This will not work with the Obins Stock firmware**
 
-To build simply type 
-```bash
-make
-```
-or
-```bash
-make MODEL=C18
-```
-if you have the C18 revision.
+To build both C15 and C18 versions run
 
+`make`
+
+to build just C15 run
+
+`make C15`
+
+to build just C18 run
+
+`make C18`
+
+The resulting `.bin` files will be in the `build` directory
+named `annepro2-shine-C15.bin` and `annepro2-shine-C18.bin`
+respectively
 
 # Contribute
 


### PR DESCRIPTION
New make behavior where default target creates both C15 and C18 builds. In addition, the targets `make C15` and `make C18` will compile just their respective versions.

The new outputs are in the `build\<version>` directories, and the `.bin` files are moved to `build` for convenient access. They're named `annepro2-shine-C15.bin` and `annepro2-shine-C15.bin` respectively.

Online instructions will need to be updated with this change.