### PR TITLE
Add logic to be able to receive a solid color as foreground from qmk

### DIFF
--- a/source/ap2_qmk_led.h
+++ b/source/ap2_qmk_led.h
@@ -13,3 +13,4 @@
 #define CMD_LED_CLEAR_MASK                  0xB
 #define CMD_LED_NEXT_INTENSITY              0xC
 #define CMD_LED_NEXT_ANIMATION_SPEED        0xD
+#define CMD_LED_SET_FOREGROUND_COLOR        0xE


### PR DESCRIPTION
Add two new methods (setForeColor and resetForeColor) to be able to set a custom forecolor as foreground that will override the current profile while active.
I've also removed the number on the array initialization of profiles because that adds the complexity of having to remember to update  that number whenever you add or remove a profile.