### PR TITLE
Implement reactive lighting effects

### DIFF
--- a/source/ap2_qmk_led.h
+++ b/source/ap2_qmk_led.h
@@ -14,3 +14,4 @@
 #define CMD_LED_NEXT_INTENSITY              0xC
 #define CMD_LED_NEXT_ANIMATION_SPEED        0xD
 #define CMD_LED_SET_FOREGROUND_COLOR        0xE
+#define CMD_LED_KEYPRESS                    0xF

--- a/source/miniFastLED.c
+++ b/source/miniFastLED.c
@@ -99,7 +99,6 @@ void hsv2rgb(uint8_t hue, uint8_t sat, uint8_t val, uint8_t* rgbResults){
         rgbResults[1] = rampup_adj_with_floor;
         rgbResults[2] = brightness_floor;
     }
-
 }
 
 // Set all keys to HSV color

--- a/source/profiles.c
+++ b/source/profiles.c
@@ -1,5 +1,6 @@
 #include "profiles.h"
 #include "miniFastLED.h"
+#include "string.h"
 
 // An array of basic colors used accross different lighting profiles
 // static const uint32_t colorPalette[] = {0xFF0000, 0xF0F00, 0x00F00, 0x00F0F,
@@ -123,4 +124,36 @@ void animatedWave(led_t* currentKeyLedColors, uint8_t intensity){
     setColumnColorHSV(currentKeyLedColors, i, 190, 255, waveValue[i], intensity);
     waveValue[i] += waveDirection[i];
   }
+}
+
+uint8_t animatedPressedFadeBuf[NUM_ROW * NUM_COLUMN] = { 0 };
+
+void reactiveFade(led_t* ledColors, uint8_t intensity) {
+  for (int i = 0; i < NUM_ROW * NUM_COLUMN; i++) {
+    if (animatedPressedFadeBuf[i] > 5) {
+      animatedPressedFadeBuf[i] -= 5;
+      hsv2rgb(100 - animatedPressedFadeBuf[i], 255, 125, (uint8_t*)&ledColors[i]);
+      ledColors[i].red >>= intensity;
+      ledColors[i].green >>= intensity;
+      ledColors[i].blue >>= intensity;
+    } else if (animatedPressedFadeBuf[i] > 0) {
+      ledColors[i].blue = 0;
+      ledColors[i].red = 0;
+      ledColors[i].green = 0;
+      animatedPressedFadeBuf[i] = 0;
+    }
+  }
+}
+
+void reactiveFadeKeypress(led_t* ledColors, uint8_t row, uint8_t col, uint8_t intensity) {
+  int i = row * NUM_COLUMN + col;
+  animatedPressedFadeBuf[i] = 100;
+  ledColors[i].green = 0;
+  ledColors[i].red = 0xFF >> intensity;
+  ledColors[i].blue = 0;
+}
+
+void reactiveFadeInit(led_t* ledColors) {
+  memset(animatedPressedFadeBuf, 0, sizeof(animatedPressedFadeBuf));
+  memset(ledColors, 0, NUM_ROW * NUM_COLUMN * 3);
 }

--- a/source/profiles.h
+++ b/source/profiles.h
@@ -19,3 +19,10 @@ void animatedRainbowWaterfall(led_t* currentKeyLedColors, uint8_t intensity);
 void animatedBreathing(led_t* currentKeyLedColors, uint8_t intensity);
 void animatedSpectrum(led_t* currentKeyLedColors, uint8_t intensity);
 void animatedWave(led_t* currentKeyLedColors, uint8_t intensity);
+
+/*
+ * ANIMATED - responding to key presses
+ */
+void reactiveFade(led_t* ledColors, uint8_t intensity);
+void reactiveFadeKeypress(led_t* ledColors, uint8_t row, uint8_t col, uint8_t intensity);
+void reactiveFadeInit(led_t* ledColors);


### PR DESCRIPTION
Implement the first effect which reacts to user keypresses.
In code I called such effects "reactive". Needs to be merged with [this PR](https://github.com/OpenAnnePro/qmk_firmware/pull/18)

This effect makes the issue of light bleed reported in https://github.com/OpenAnnePro/AnnePro2-Shine/issues/17
very noticeable. Noticeable not because of this code, noticeable because now we light up each key separately.
Will try to address it in a separate PR.