### PR TITLE
Unify all callbacks into one to improve performance

### DIFF
--- a/cfg/chconf.h
+++ b/cfg/chconf.h
@@ -130,7 +130,7 @@
  *          infinite loop.
  */
 #if !defined(CH_CFG_NO_IDLE_THREAD)
-#define CH_CFG_NO_IDLE_THREAD               FALSE
+#define CH_CFG_NO_IDLE_THREAD               TRUE
 #endif
 
 

--- a/cfg/mcuconf.h
+++ b/cfg/mcuconf.h
@@ -51,14 +51,14 @@
  */
 
 #define HT32_GPT_USE_BFTM0                  TRUE
-#define HT32_GPT_BFTM0_IRQ_PRIORITY         4
+#define HT32_GPT_BFTM0_IRQ_PRIORITY         3
 
 #define HT32_SERIAL_USE_USART0              FALSE
 #define HT32_SERIAL_USE_USART1              TRUE
-#define HT32_USART1_IRQ_PRIORITY            3
+#define HT32_USART1_IRQ_PRIORITY            2
 
-#define HT32_GPT_USE_BFTM1                  TRUE
-#define HT32_GPT_BFTM1_IRQ_PRIORITY         5
+#define HT32_GPT_USE_BFTM1                  FALSE
+#define HT32_GPT_BFTM1_IRQ_PRIORITY         3
 /*
  * USB driver settings
  */


### PR DESCRIPTION
Currently the performance of the animation effects is not great. There are some stutters which happen from time to time.
That is especially noticeable in the reactive effect - `reactiveFade`. When typing large number of keys, the key animation does not keep up. Some keys light up later, some don't light up at all.

Based on my blackbox investigation, I believe that is due to context switches that happen on the MCU.
Currently there are 3 threads which do the work
* main thread, handling messages over serial
* column callback responsible for enabling LEDs
* animation callback

In the PR, I am making the main thread idle.
`animationCallback` is removed.
`columnCallback` is renamed into `mainLoop` because now it contains the logic of all 3.

This gives us several advantages:
* when animation is disabled, we don't need to call `mainLoop` that often, because handling serial with less frequency is OK. That should save some battery
* because all work is done in one thread, we don't need to use locking with `chSysLock`
* there are less context switches, less stutters.

The easiest way to compare this work would be to run `reactiveFade` animation and press random keys very quickly. It works much better on my board than current version.
