### PR TITLE
Improve responsiveness of shine and reduce bleed between LEDs

### DIFF
--- a/cfg/chconf.h
+++ b/cfg/chconf.h
@@ -130,7 +130,7 @@
  *          infinite loop.
  */
 #if !defined(CH_CFG_NO_IDLE_THREAD)
-#define CH_CFG_NO_IDLE_THREAD               TRUE
+#define CH_CFG_NO_IDLE_THREAD               FALSE
 #endif
 
 

--- a/cfg/mcuconf.h
+++ b/cfg/mcuconf.h
@@ -50,7 +50,7 @@
  * Peripheral driver settings
  */
 
-#define HT32_GPT_USE_BFTM0                  TRUE
+#define HT32_GPT_USE_BFTM0                  FALSE
 #define HT32_GPT_BFTM0_IRQ_PRIORITY         3
 
 #define HT32_SERIAL_USE_USART0              FALSE

--- a/source/light_utils.c
+++ b/source/light_utils.c
@@ -50,7 +50,7 @@ void setModKeysColor(led_t *ledColors, uint32_t color, uint8_t intensity) {
 }
 
 // Set specific key color
-void setKeyColor(led_t *key, uint32_t color, uint8_t intensity) {
+inline void setKeyColor(led_t *key, uint32_t color, uint8_t intensity) {
   key->red = ((color >> 16) & 0xFF) >> intensity;
   key->green = ((color >> 8) & 0xFF) >> intensity;
   key->blue = (color & 0xFF) >> intensity;

--- a/source/profiles.c
+++ b/source/profiles.c
@@ -5,48 +5,54 @@
 // An array of basic colors used accross different lighting profiles
 // static const uint32_t colorPalette[] = {0xFF0000, 0xF0F00, 0x00F00, 0x00F0F,
 // 0x0000F, 0xF000F, 0x50F0F};
-static const uint32_t colorPalette[] = {0x9c0000, 0x9c9900, 0x1f9c00, 0x00979c,
-                                        0x003e9c, 0x39009c, 0x9c008f};
+static const uint32_t colorPalette[] = {0xcc0000, 0xccc900, 0x5fcc00, 0x00c7cc,
+                                        0x006ecc, 0x0033ff, 0x6900cc, 0xcc00bf};
 
 #define LEN(a) (sizeof(a) / sizeof(*a))
 
-void red(led_t *currentKeyLedColors, uint8_t intensity) {
+bool red(led_t *currentKeyLedColors, uint8_t intensity) {
   setAllKeysColor(currentKeyLedColors, 0xFF0000, intensity);
+  return true;
 }
 
-void green(led_t *currentKeyLedColors, uint8_t intensity) {
+bool green(led_t *currentKeyLedColors, uint8_t intensity) {
   setAllKeysColor(currentKeyLedColors, 0x00FF00, intensity);
+  return true;
 }
 
-void blue(led_t *currentKeyLedColors, uint8_t intensity) {
+bool blue(led_t *currentKeyLedColors, uint8_t intensity) {
   setAllKeysColor(currentKeyLedColors, 0x0000FF, intensity);
+  return true;
 }
 
-void miamiNights(led_t *currentKeyLedColors, uint8_t intensity) {
+bool miamiNights(led_t *currentKeyLedColors, uint8_t intensity) {
   setAllKeysColor(currentKeyLedColors, 0x00979c, intensity);
   setModKeysColor(currentKeyLedColors, 0x9c008f, intensity);
+  return true;
 }
 
-void rainbowHorizontal(led_t *currentKeyLedColors, uint8_t intensity) {
+bool rainbowHorizontal(led_t *currentKeyLedColors, uint8_t intensity) {
   for (uint16_t i = 0; i < NUM_ROW; ++i) {
     for (uint16_t j = 0; j < NUM_COLUMN; ++j) {
       setKeyColor(&currentKeyLedColors[i * NUM_COLUMN + j],
                   colorPalette[i % LEN(colorPalette)], intensity);
     }
   }
+  return true;
 }
 
-void rainbowVertical(led_t *currentKeyLedColors, uint8_t intensity) {
+bool rainbowVertical(led_t *currentKeyLedColors, uint8_t intensity) {
   for (uint16_t i = 0; i < NUM_COLUMN; ++i) {
     for (uint16_t j = 0; j < NUM_ROW; ++j) {
       setKeyColor(&currentKeyLedColors[j * NUM_COLUMN + i],
                   colorPalette[i % LEN(colorPalette)], intensity);
     }
   }
+  return true;
 }
 
 static uint8_t colAnimOffset = 0;
-void animatedRainbowVertical(led_t *currentKeyLedColors, uint8_t intensity) {
+bool animatedRainbowVertical(led_t *currentKeyLedColors, uint8_t intensity) {
   for (uint16_t i = 0; i < NUM_COLUMN; ++i) {
     for (uint16_t j = 0; j < NUM_ROW; ++j) {
       setKeyColor(&currentKeyLedColors[j * NUM_COLUMN + i],
@@ -55,24 +61,26 @@ void animatedRainbowVertical(led_t *currentKeyLedColors, uint8_t intensity) {
     }
   }
   colAnimOffset = (colAnimOffset + 1) % LEN(colorPalette);
+  return true;
 }
 
 static uint8_t flowValue[NUM_COLUMN] = {0,  11, 22, 33,  44,  55,  66,
                                         77, 88, 99, 110, 121, 132, 143};
-void animatedRainbowFlow(led_t *currentKeyLedColors, uint8_t intensity) {
+bool animatedRainbowFlow(led_t *currentKeyLedColors, uint8_t intensity) {
   for (int i = 0; i < NUM_COLUMN; i++) {
-    setColumnColorHSV(currentKeyLedColors, i, flowValue[i], 255, 125,
+    setColumnColorHSV(currentKeyLedColors, i, flowValue[i], 255, 255,
                       intensity);
     if (flowValue[i] >= 179 && flowValue[i] < 240) {
       flowValue[i] = 240;
     }
     flowValue[i] += 3;
   }
+  return true;
 }
 
 static uint8_t waterfallValue[NUM_COLUMN] = {0,  10, 20, 30,  40,  50,  60,
                                              70, 80, 90, 100, 110, 120, 130};
-void animatedRainbowWaterfall(led_t *currentKeyLedColors, uint8_t intensity) {
+bool animatedRainbowWaterfall(led_t *currentKeyLedColors, uint8_t intensity) {
   for (int i = 0; i < NUM_ROW; i++) {
     setRowColorHSV(currentKeyLedColors, i, waterfallValue[i], 255, 125,
                    intensity);
@@ -81,11 +89,12 @@ void animatedRainbowWaterfall(led_t *currentKeyLedColors, uint8_t intensity) {
     }
     waterfallValue[i] += 3;
   }
+  return true;
 }
 
 static uint8_t breathingValue = 180;
 static int breathingDirection = -1;
-void animatedBreathing(led_t *currentKeyLedColors, uint8_t intensity) {
+bool animatedBreathing(led_t *currentKeyLedColors, uint8_t intensity) {
   setAllKeysColorHSV(currentKeyLedColors, 85, 255, breathingValue, intensity);
   if (breathingValue >= 180) {
     breathingDirection = -3;
@@ -93,11 +102,12 @@ void animatedBreathing(led_t *currentKeyLedColors, uint8_t intensity) {
     breathingDirection = 3;
   }
   breathingValue += breathingDirection;
+  return true;
 }
 
 static uint8_t spectrumValue = 2;
 static int spectrumDirection = 1;
-void animatedSpectrum(led_t *currentKeyLedColors, uint8_t intensity) {
+bool animatedSpectrum(led_t *currentKeyLedColors, uint8_t intensity) {
   setAllKeysColorHSV(currentKeyLedColors, spectrumValue, 255, 125, intensity);
   if (spectrumValue >= 177) {
     spectrumDirection = -3;
@@ -105,13 +115,14 @@ void animatedSpectrum(led_t *currentKeyLedColors, uint8_t intensity) {
     spectrumDirection = 3;
   }
   spectrumValue += spectrumDirection;
+  return true;
 }
 
 static uint8_t waveValue[NUM_COLUMN] = {0,  0,  0,  10,  15,  20,  25,
                                         40, 55, 75, 100, 115, 135, 140};
 static int waveDirection[NUM_COLUMN] = {3, 3, 3, 3, 3, 3, 3,
                                         3, 3, 3, 3, 3, 3, 3};
-void animatedWave(led_t *currentKeyLedColors, uint8_t intensity) {
+bool animatedWave(led_t *currentKeyLedColors, uint8_t intensity) {
   for (int i = 0; i < NUM_COLUMN; i++) {
     if (waveValue[i] >= 140) {
       waveDirection[i] = -3;
@@ -122,26 +133,31 @@ void animatedWave(led_t *currentKeyLedColors, uint8_t intensity) {
                       intensity);
     waveValue[i] += waveDirection[i];
   }
+  return true;
 }
 
 uint8_t animatedPressedFadeBuf[NUM_ROW * NUM_COLUMN] = {0};
 
-void reactiveFade(led_t *ledColors, uint8_t intensity) {
+bool reactiveFade(led_t *ledColors, uint8_t intensity) {
+  bool shouldUpdate = false;
   for (int i = 0; i < NUM_ROW * NUM_COLUMN; i++) {
     if (animatedPressedFadeBuf[i] > 5) {
+      shouldUpdate = true;
       animatedPressedFadeBuf[i] -= 5;
-      hsv2rgb(100 - animatedPressedFadeBuf[i], 255, 125,
+      hsv2rgb(100 - animatedPressedFadeBuf[i], 255, 225,
               (uint8_t *)&ledColors[i]);
       ledColors[i].red >>= intensity;
       ledColors[i].green >>= intensity;
       ledColors[i].blue >>= intensity;
     } else if (animatedPressedFadeBuf[i] > 0) {
+      shouldUpdate = true;
       ledColors[i].blue = 0;
       ledColors[i].red = 0;
       ledColors[i].green = 0;
       animatedPressedFadeBuf[i] = 0;
     }
   }
+  return shouldUpdate;
 }
 
 void reactiveFadeKeypress(led_t *ledColors, uint8_t row, uint8_t col,
@@ -154,6 +170,12 @@ void reactiveFadeKeypress(led_t *ledColors, uint8_t row, uint8_t col,
 }
 
 void reactiveFadeInit(led_t *ledColors) {
-  memset(animatedPressedFadeBuf, 0, sizeof(animatedPressedFadeBuf));
+  // create a quick "falling" animation to make it easier to see
+  // that this profile is activated
+  for (int i = 0; i < NUM_ROW; i++) {
+    for (int j = 0; j < NUM_COLUMN; j++) {
+      animatedPressedFadeBuf[i * NUM_COLUMN + j] = i * 15 + 25;
+    }
+  }
   memset(ledColors, 0, NUM_ROW * NUM_COLUMN * 3);
 }

--- a/source/profiles.h
+++ b/source/profiles.h
@@ -3,27 +3,27 @@
 /*
  * STATIC
  */
-void red(led_t *currentKeyLedColors, uint8_t intensity);
-void green(led_t *currentKeyLedColors, uint8_t intensity);
-void blue(led_t *currentKeyLedColors, uint8_t intensity);
-void rainbowHorizontal(led_t *currentKeyLedColors, uint8_t intensity);
-void rainbowVertical(led_t *currentKeyLedColors, uint8_t intensity);
-void miamiNights(led_t *currentKeyLedColors, uint8_t intensity);
+bool red(led_t *currentKeyLedColors, uint8_t intensity);
+bool green(led_t *currentKeyLedColors, uint8_t intensity);
+bool blue(led_t *currentKeyLedColors, uint8_t intensity);
+bool rainbowHorizontal(led_t *currentKeyLedColors, uint8_t intensity);
+bool rainbowVertical(led_t *currentKeyLedColors, uint8_t intensity);
+bool miamiNights(led_t *currentKeyLedColors, uint8_t intensity);
 
 /*
  * ANIMATED
  */
-void animatedRainbowVertical(led_t *currentKeyLedColors, uint8_t intensity);
-void animatedRainbowFlow(led_t *currentKeyLedColors, uint8_t intensity);
-void animatedRainbowWaterfall(led_t *currentKeyLedColors, uint8_t intensity);
-void animatedBreathing(led_t *currentKeyLedColors, uint8_t intensity);
-void animatedSpectrum(led_t *currentKeyLedColors, uint8_t intensity);
-void animatedWave(led_t *currentKeyLedColors, uint8_t intensity);
+bool animatedRainbowVertical(led_t *currentKeyLedColors, uint8_t intensity);
+bool animatedRainbowFlow(led_t *currentKeyLedColors, uint8_t intensity);
+bool animatedRainbowWaterfall(led_t *currentKeyLedColors, uint8_t intensity);
+bool animatedBreathing(led_t *currentKeyLedColors, uint8_t intensity);
+bool animatedSpectrum(led_t *currentKeyLedColors, uint8_t intensity);
+bool animatedWave(led_t *currentKeyLedColors, uint8_t intensity);
 
 /*
  * ANIMATED - responding to key presses
  */
-void reactiveFade(led_t *ledColors, uint8_t intensity);
+bool reactiveFade(led_t *ledColors, uint8_t intensity);
 void reactiveFadeKeypress(led_t *ledColors, uint8_t row, uint8_t col,
                           uint8_t intensity);
 void reactiveFadeInit(led_t *ledColors);


### PR DESCRIPTION
This improves the bleed between neighboring LEDs. My change is based on empirical testing and I am not sure about the underlying reason why this change helps. I am switching from column based PWM to row based PWM solution.
The brightness of static effects got little bit lower. I could not get it the same as before. It might be due to the reduced bleed between LEDs.

To test the bleeding improvements, enable the reactive profile and take out one of the keycaps. Then click all its neighbors. Compare the results with the old shine.