### PR TITLE
Fix the foreground by avoiding animation when foreground is set

### DIFF
--- a/main.c
+++ b/main.c
@@ -385,7 +385,7 @@ inline uint8_t min(uint8_t a, uint8_t b) { return a <= b ? a : b; }
 static inline void animationCallback() {
   // If the foreground is set we skip the animation as a way to avoid it
   // overrides the foreground
-  if(is_foregroundColor_set){
+  if (is_foregroundColor_set) {
     return;
   }
 

--- a/main.c
+++ b/main.c
@@ -95,7 +95,7 @@ typedef struct {
   profile_init profileInit;
 } profile;
 
-profile profiles[12] = {
+profile profiles[] = {
     {red, {0, 0, 0, 0}, NULL, NULL},
     {green, {0, 0, 0, 0}, NULL, NULL},
     {blue, {0, 0, 0, 0}, NULL, NULL},
@@ -383,11 +383,13 @@ inline uint8_t min(uint8_t a, uint8_t b) { return a <= b ? a : b; }
  * Update lighting table as per animation
  */
 static inline void animationCallback() {
-
   // If the foreground is set we skip the animation as a way to avoid it
   // overrides the foreground
-  if (!is_foregroundColor_set &&
-      profiles[currentProfile].animationSpeed[currentSpeed] > 0) {
+  if(is_foregroundColor_set){
+    return;
+  }
+
+  if (profiles[currentProfile].animationSpeed[currentSpeed] > 0) {
     reactiveNeedsUpdate =
         profiles[currentProfile].callback(ledColors, ledIntensity);
 


### PR DESCRIPTION
The changes to enable dynamic lighting broke the foreground color feature. The way I managed to get both working was to skip the animation method altogether when the is_foregroundColor_set is true (that's how it was implemented before the changes for the dynamic lighting, by the way).

There is still a bug with both the foreground color and new reactive fade profile - if you let the profile initial animation end while still holding a layer button, it kind of disables lighting until you change the profile again or enable and disable the leds. But with this fix at least it will work as expected if you release the layer button before the initial animation ends.