### PR TITLE
fix unresponsive reactiveFade

### DIFF
--- a/source/profiles.c
+++ b/source/profiles.c
@@ -149,7 +149,7 @@ bool reactiveFade(led_t *ledColors, uint8_t intensity) {
       ledColors[i].red >>= intensity;
       ledColors[i].green >>= intensity;
       ledColors[i].blue >>= intensity;
-    } else if (animatedPressedFadeBuf[i] > 0) {
+    } else {
       shouldUpdate = true;
       ledColors[i].blue = 0;
       ledColors[i].red = 0;


### PR DESCRIPTION
See #34. The issue was that the else if statement condition that I deleted was blocking it from resetting. For some reason, doing chBSemReset() in setProfile() is an alternative to this. I have no clue why. Another alternative was to outright remove the for loop in reactiveFadeInit(). I chose to remove the if statement because it seems the simplest without removing the init animation. I'm not entirely confident in this implementation, given the alternative fix.