### PR TITLE
Fix pressing fn key speeds up animation

### DIFF
--- a/main.c
+++ b/main.c
@@ -300,8 +300,15 @@ bool needToCallbackProfile = false;
 
 void clearForegroundColor() {
   foregroundColorSet = false;
-  memset(ledColors, 0, sizeof(ledColors));
-  needToCallbackProfile = true;
+
+  /* Check if current profile is reactive. If it is, clear the colors. Not doing
+   * it will keep the foreground color if it is a reactive profile This might
+   * cause a split blackout with reactive profiles in the future if they have
+   * also have static colors/animation.
+   */
+  if (profiles[currentProfile].keypressCallback != NULL) {
+    memset(ledColors, 0, sizeof(ledColors));
+  }
 }
 
 /*


### PR DESCRIPTION
This might cause a blackout for a split second if a reactive profile also has static colors/animation, but none of the reactive profiles currently have that kind of thing, meaning it might be a problem in the future.