### PR TITLE
Reduce bleed between neighboring keys

### DIFF
--- a/main.c
+++ b/main.c
@@ -443,8 +443,6 @@ static inline void animationCallback() {
 static inline void sPWM(uint8_t cycle, uint8_t currentCount, ioline_t port) {
   if (cycle > currentCount) {
     palSetLine(port);
-  } else {
-    palClearLine(port);
   }
 }
 
@@ -459,6 +457,11 @@ void mainCallback(GPTDriver *_driver) {
   if (ledEnabled) {
 
     palClearLine(ledColumns[currentCol]);
+    for (int i = 0; i < NUM_ROW * 4; i++) {
+      if (i % 4 != 3) {
+        palClearLine(ledRows[i]);
+      }
+    }
 
     if (needToCallbackProfile) {
       needToCallbackProfile = false;


### PR DESCRIPTION
Small change updates sPWM logic by adding a small delay between disabling of the current column and enabling the next column.
The diff can be seen from this video. The current version looks [like this](https://i.imgur.com/RBfRU0F.mp4)

With proposed changes in the PR it will look [like this](https://i.imgur.com/gSZQwPI.mp4)