### PR TITLE
Refactor + stupid animation.

### DIFF
--- a/board/board.h
+++ b/board/board.h
@@ -40,6 +40,7 @@
 
 #define NUM_COLUMN                                         14
 #define NUM_ROW                                            5
+#define KEY_COUNT                                          70
 
 #ifdef C18
 #define LINE_LED_PWR                                       PAL_LINE(IOPORTA, 10)

--- a/main.c
+++ b/main.c
@@ -19,15 +19,14 @@
 #include "ch.h"
 #include "hal.h"
 #include "light_utils.h"
+#include "matrix.h"
 #include "miniFastLED.h"
 #include "profiles.h"
+#include "settings.h"
 #include "string.h"
 
-static void animationCallback(void);
 static void executeMsg(msg_t msg);
 static void executeProfile(bool init);
-static void disableLeds(void);
-static void enableLeds(void);
 static void ledSet(void);
 static void ledSetRow(void);
 static void setProfile(void);
@@ -38,129 +37,8 @@ static void setForegroundColor(void);
 static void clearForegroundColor(void);
 static void handleKeypress(msg_t msg);
 static void setIAP(void);
-static void pwmRowDimmer(void);
-static void pwmNextColumn(void);
-static void mainCallback(GPTDriver *_driver);
-
-ioline_t ledColumns[NUM_COLUMN] = {
-    LINE_LED_COL_1,  LINE_LED_COL_2,  LINE_LED_COL_3,  LINE_LED_COL_4,
-    LINE_LED_COL_5,  LINE_LED_COL_6,  LINE_LED_COL_7,  LINE_LED_COL_8,
-    LINE_LED_COL_9,  LINE_LED_COL_10, LINE_LED_COL_11, LINE_LED_COL_12,
-    LINE_LED_COL_13, LINE_LED_COL_14};
-
-ioline_t ledRows[NUM_ROW * 3] = {
-    LINE_LED_ROW_1_R, LINE_LED_ROW_1_G, LINE_LED_ROW_1_B,
-
-    LINE_LED_ROW_2_R, LINE_LED_ROW_2_G, LINE_LED_ROW_2_B,
-
-    LINE_LED_ROW_3_R, LINE_LED_ROW_3_G, LINE_LED_ROW_3_B,
-
-    LINE_LED_ROW_4_R, LINE_LED_ROW_4_G, LINE_LED_ROW_4_B,
-
-    LINE_LED_ROW_5_R, LINE_LED_ROW_5_G, LINE_LED_ROW_5_B,
-};
-
-#define KEY_COUNT 70
 
 #define LEN(a) (sizeof(a) / sizeof(*a))
-
-/*
- * Active profiles
- * Add profiles from source/profiles.h in the profile array
- */
-typedef void (*lighting_callback)(led_t *);
-
-/*
- * keypress handler
- */
-typedef void (*keypress_handler)(led_t *colors, uint8_t row, uint8_t col);
-
-typedef void (*profile_init)(led_t *colors);
-
-typedef struct {
-  // callback function implementing the lighting effect
-  lighting_callback callback;
-  // For static effects, their `callback` is called only once.
-  // For dynamic effects, their `callback` is called in a loop.
-  //
-  // This field controls the animation speed by specifying how many LED refresh
-  // cycles to skip before calling the callback again. For example, 1 in the
-  // array means that `callback` is called on every cycle, ie. ~71Hz on default
-  // settings.
-  //
-  // Different 4 values can be specified to allow different speeds of the same
-  // effect. For static effects, the array must contain {0, 0, 0, 0}.
-  uint16_t animationSpeed[4];
-  // In case the profile is reactive, it responds to each keypress.
-  // This callback is called with the locations of the pressed keys.
-  keypress_handler keypressCallback;
-  // Some profiles might need additional setup when just enabled.
-  // This callback defines such logic if needed.
-  profile_init profileInit;
-} profile;
-
-profile profiles[] = {
-    /* {colorBleed, {0, 0, 0, 0}, NULL, NULL}, */
-    {red, {0, 0, 0, 0}, NULL, NULL},
-    {green, {0, 0, 0, 0}, NULL, NULL},
-    {blue, {0, 0, 0, 0}, NULL, NULL},
-    {rainbowHorizontal, {0, 0, 0, 0}, NULL, NULL},
-    {rainbowVertical, {0, 0, 0, 0}, NULL, NULL},
-    {animatedRainbowVertical, {35, 28, 21, 14}, NULL, NULL},
-    {animatedRainbowFlow, {7, 5, 2, 1}, NULL, NULL},
-    {animatedRainbowWaterfall, {7, 5, 2, 1}, NULL, NULL},
-    {animatedBreathing, {5, 3, 2, 1}, NULL, NULL},
-    {animatedWave, {5, 3, 2, 1}, NULL, NULL},
-    {animatedSpectrum, {11, 6, 4, 1}, NULL, NULL},
-    {reactiveFade, {4, 3, 2, 1}, reactiveFadeKeypress, reactiveFadeInit},
-    {reactivePulse, {4, 3, 2, 1}, reactivePulseKeypress, reactivePulseInit}};
-
-static uint8_t currentProfile = 0;
-static const uint8_t amountOfProfiles = sizeof(profiles) / sizeof(profile);
-static volatile uint8_t currentSpeed = 0;
-
-/* If non-zero the animation is enabled; 1 is full speed */
-static volatile uint16_t animationSkipTicks = 0;
-
-/* Animation tick counter used to slow down animations */
-static uint16_t animationTicks = 0;
-
-/*
-   Original firmware reference:
-   ~9.81ms column cycle measured -> 100Hz.
-
-   During each column cycle the row is "strobed" 3 - 32 times (measured on white
-   with different intensity settings). This wastes some shining time, but limits
-   the current.
-
-   The row strobing is done at around 70kHz.
-
-   We would like to achieve more colors than the original firmware.
-
-   80kHz with pwmCounterLimit=80 will scan 14 columns at 71.4Hz - enough for
-   smooth animations, and allows for 6bit LED brightness control.
-
-   Tests on oscilloscope suggest it can reach 100kHz.
- */
-static const GPTConfig bftm0Config = {.frequency = 80000,
-                                      .callback = mainCallback};
-
-static mutex_t mtx;
-
-// Default zero corresponds to full intensity. Each color has the intensity
-// decreased linearly with this setting by the PWM loop.
-static uint8_t ledIntensity = 0;
-
-static volatile bool ledEnabled = false;
-
-// Flag to check if there is a foreground color currently active
-static bool foregroundColorSet = false;
-static uint32_t foregroundColor = 0;
-
-uint8_t ledMasks[KEY_COUNT];
-led_t ledColors[KEY_COUNT];
-
-static uint8_t currentColumn = 0;
 
 static const SerialConfig usart1Config = {.speed = 115200};
 
@@ -191,10 +69,11 @@ void forwardReactiveFlag(void) {
 static inline void executeMsg(msg_t msg) {
   switch (msg) {
   case CMD_LED_ON:
-    enableLeds();
+    executeProfile(true);
+    matrixEnable();
     break;
   case CMD_LED_OFF:
-    disableLeds();
+    matrixDisable();
     break;
   case CMD_LED_SET:
     ledSet();
@@ -316,10 +195,6 @@ void setForegroundColor() {
   }
 }
 
-// In case we switched to a new profile, the mainCallback
-// should call the profile handler initially when this flag is set to true.
-bool needToCallbackProfile = false;
-
 void clearForegroundColor() {
   foregroundColorSet = false;
 
@@ -372,54 +247,6 @@ void executeProfile(bool init) {
 }
 
 /*
- * Turn off all leds
- */
-static inline void disableLeds() {
-
-  chMtxLock(&mtx);
-
-  ledEnabled = false;
-
-  // stop timer, clock is still enabled
-  if (GPTD_BFTM0.state == GPT_CONTINUOUS) {
-    gptStopTimer(&GPTD_BFTM0);
-  }
-  // enter low power mode
-  if (GPTD_BFTM0.state == GPT_READY) {
-    gptStop(&GPTD_BFTM0);
-  }
-
-  palClearLine(LINE_LED_PWR);
-
-  for (int ledRow = 0; ledRow < NUM_ROW * 3; ledRow++) {
-    palClearLine(ledRows[ledRow]);
-  }
-  for (int i = 0; i < NUM_COLUMN; i++) {
-    palClearLine(ledColumns[i]);
-  }
-
-  chMtxUnlock(&mtx);
-}
-
-/*
- * Turn on all leds
- */
-static inline void enableLeds(void) {
-  chMtxLock(&mtx);
-  ledEnabled = true;
-
-  executeProfile(true);
-
-  palSetLine(LINE_LED_PWR);
-
-  // start PWM handling interval
-  gptStart(&GPTD_BFTM0, &bftm0Config);
-  gptStartContinuous(&GPTD_BFTM0, 1);
-
-  chMtxUnlock(&mtx);
-}
-
-/*
  * Set a led based on qmk communication
  */
 void ledSet() {
@@ -439,6 +266,7 @@ void ledSet() {
  */
 void ledSetRow() {
   size_t bytesRead;
+  /* FIXME: Unify with the main chip or remove */
   bytesRead =
       sdReadTimeout(&SD1, commandBuffer, sizeof(led_t) * NUM_COLUMN + 1, 1000);
   if (bytesRead >= sizeof(led_t) * NUM_COLUMN + 1) {
@@ -451,134 +279,6 @@ void ledSetRow() {
 }
 
 inline uint8_t min(uint8_t a, uint8_t b) { return a <= b ? a : b; }
-
-/*
- * Update lighting table as per animation
- */
-static inline void animationCallback() {
-  // If the foreground is set we skip the animation as a way to avoid it
-  // overrides the foreground
-  if (foregroundColorSet) {
-    return;
-  }
-  profiles[currentProfile].callback(ledColors);
-}
-
-/*
- * Time each row has left to shine within the current column cycle.
- * Row1 R-G-B, Row2 R-G-B, Row3 R-G-B, ...
- */
-uint8_t rowTimes[NUM_ROW * 3];
-uint8_t rowsEnabled;
-
-/*
- * pwmCounter which counts time of lit rows within each column cycle.
- */
-uint16_t pwmCounter;
-
-/*
- * pwmCounter goes over 64 a bit to limit the current of completely white
- * board (0.5A) vs <0.3A for original firmware.
- *
- * You can get brighter LEDs if you set this to 64. And possibly burn the
- * board in the longer period of time.
- */
-const uint16_t pwmCounterLimit = 80;
-
-/* Disable timeouted LEDs */
-static inline void pwmRowDimmer() {
-  for (size_t ledRow = 0; ledRow < NUM_ROW * 3; ledRow++) {
-    const uint8_t time = rowTimes[ledRow];
-    if (pwmCounter == time) {
-      palClearLine(ledRows[ledRow]);
-      rowsEnabled--;
-    }
-  }
-  if (rowsEnabled == 0) {
-    /* Limit color bleed by disabling the column as early as possible */
-    palClearLine(ledColumns[currentColumn]);
-  }
-}
-
-/* Start new PWM cycle */
-static inline void pwmNextColumn() {
-  /* Disable previously lit column */
-  palClearLine(ledColumns[currentColumn]);
-
-  currentColumn = (currentColumn + 1) % NUM_COLUMN;
-
-  /* TODO: Minimum intensity per animation? For some, the darkness doesn't work
-     well (rainbow) */
-  const uint8_t intensityDecrease = ledIntensity * 8;
-
-  /* Prepare the PWM data and enable leds for non-zero colors */
-  rowsEnabled = 0;
-  for (size_t keyRow = 0; keyRow < NUM_ROW; keyRow++) {
-    const uint8_t ledIndex = ROWCOL2IDX(keyRow, currentColumn);
-    const led_t cl = ledColors[ledIndex];
-
-    for (size_t colorIdx = 0; colorIdx < 3; colorIdx++) {
-      const uint8_t ledRow = 3 * keyRow + colorIdx;
-      /* >>2 to decrease the color resolution from 0-255 to 0-63 */
-      uint8_t color = cl.pv[2 - colorIdx] >> 2;
-      if (intensityDecrease >= color) {
-        color = 0;
-      } else {
-        color -= intensityDecrease;
-        /* Each led is enabled for color>0 even for a short while. */
-        palSetLine(ledRows[ledRow]);
-        rowsEnabled++;
-      }
-      rowTimes[ledRow] = color;
-    }
-  }
-
-  /* Enable the current LED column if at least one row needs this. Limit bleed
-     and maybe power consumption on reactive profiles. */
-  if (rowsEnabled) {
-    palSetLine(ledColumns[currentColumn]);
-  }
-}
-
-// mainCallback is responsible for 2 things:
-// * software PWM
-// * calling animation callback for animated profiles
-void mainCallback(GPTDriver *_driver) {
-  (void)_driver;
-
-  if (!ledEnabled) {
-    return;
-  }
-
-  pwmCounter += 1;
-  if (pwmCounter < pwmCounterLimit) {
-    pwmRowDimmer();
-    return;
-  }
-
-  /* Update profile if required before starting new cycle */
-  if (needToCallbackProfile) {
-    needToCallbackProfile = false;
-    profiles[currentProfile].callback(ledColors);
-  }
-
-  /* Animation can be updated after each full column cycle. On
-   * pwmCounterLimit=80 + 80kHz timer this refreshes at 80kHz/80/14 = 71Hz and
-   * should be a sensible maximum speed for a fluent smooth animation.
-   */
-  if (animationSkipTicks > 0 && currentColumn == 13) {
-    animationTicks++;
-    if (animationTicks >= animationSkipTicks) {
-      animationTicks = 0;
-      animationCallback();
-    }
-  }
-
-  /* We start a new PWM column cycle. */
-  pwmCounter = 0;
-
-  pwmNextColumn();
-}
 
 /*
  * Application entry point.
@@ -599,7 +299,7 @@ int main(void) {
   // Setup masks to all be 0xFF at the start
   memset(ledMasks, 0xFF, sizeof(ledMasks));
 
-  chMtxObjectInit(&mtx);
+  matrixInit();
 
   palClearLine(LINE_LED_PWR);
   sdStart(&SD1, &usart1Config);

--- a/source/light_utils.h
+++ b/source/light_utils.h
@@ -4,9 +4,6 @@
 #include "board.h"
 #include "hal.h"
 
-/*
-    Structs
-*/
 // Struct defining an LED and its RGB color components
 typedef union {
   struct {
@@ -19,9 +16,6 @@ typedef union {
   /* 0xrgb in mem is b g r X */
   uint32_t rgb;
 } led_t;
-
-// Calculate position within the ledColors array
-#define ROWCOL2IDX(row, col) (NUM_COLUMN * (row) + (col))
 
 /*
     Function Signatures

--- a/source/matrix.c
+++ b/source/matrix.c
@@ -1,0 +1,240 @@
+/* Algorithm controlling the LEDs. */
+
+#include "matrix.h"
+#include "board.h"
+#include "hal.h"
+#include "settings.h"
+
+/* LED Matrix state */
+led_t ledColors[KEY_COUNT];
+bool needToCallbackProfile = false;
+
+/* Animations */
+/* If non-zero the animation is enabled; 1 is full speed */
+volatile uint16_t animationSkipTicks = 0;
+
+/* Animation tick counter used to slow down animations */
+uint16_t animationTicks = 0;
+
+/* Forced colors by main chip */
+// Flag to check if there is a foreground color currently active
+bool foregroundColorSet = false;
+uint32_t foregroundColor = 0;
+
+uint8_t ledMasks[KEY_COUNT];
+
+/* Internal function prototypes */
+static void animationCallback(void);
+static void mainCallback(GPTDriver *_driver);
+static void pwmRowDimmer(void);
+static void pwmNextColumn(void);
+
+const ioline_t ledColumns[NUM_COLUMN] = {
+    LINE_LED_COL_1,  LINE_LED_COL_2,  LINE_LED_COL_3,  LINE_LED_COL_4,
+    LINE_LED_COL_5,  LINE_LED_COL_6,  LINE_LED_COL_7,  LINE_LED_COL_8,
+    LINE_LED_COL_9,  LINE_LED_COL_10, LINE_LED_COL_11, LINE_LED_COL_12,
+    LINE_LED_COL_13, LINE_LED_COL_14};
+
+const ioline_t ledRows[NUM_ROW * 3] = {
+    LINE_LED_ROW_1_R, LINE_LED_ROW_1_G, LINE_LED_ROW_1_B,
+
+    LINE_LED_ROW_2_R, LINE_LED_ROW_2_G, LINE_LED_ROW_2_B,
+
+    LINE_LED_ROW_3_R, LINE_LED_ROW_3_G, LINE_LED_ROW_3_B,
+
+    LINE_LED_ROW_4_R, LINE_LED_ROW_4_G, LINE_LED_ROW_4_B,
+
+    LINE_LED_ROW_5_R, LINE_LED_ROW_5_G, LINE_LED_ROW_5_B,
+};
+
+static mutex_t mtx;
+
+/*
+  Original firmware reference:
+  ~9.81ms column cycle measured -> 100Hz.
+
+  During each column cycle the row is "strobed" 3 - 32 times (measured on white
+  with different intensity settings). This wastes some shining time, but limits
+  the current.
+
+  The row strobing is done at around 70kHz.
+
+  We would like to achieve more colors than the original firmware.
+
+  80kHz with pwmCounterLimit=80 will scan 14 columns at 71.4Hz - enough for
+  smooth animations, and allows for 6bit LED brightness control.
+
+  Tests on oscilloscope suggest it can reach 100kHz.
+*/
+static const GPTConfig bftm0Config = {.frequency = 80000,
+                                      .callback = mainCallback};
+
+/* Currently scanned column */
+static uint8_t currentColumn = 0;
+
+/*
+ * Time each row has left to shine within the current column cycle.
+ * Row1 R-G-B, Row2 R-G-B, Row3 R-G-B, ...
+ */
+static uint8_t rowTimes[NUM_ROW * 3];
+
+/* Number of still enabled rows in current column */
+static uint8_t rowsEnabled;
+
+/*
+ * pwmCounter which counts time of lit rows within each column cycle.
+ */
+uint16_t pwmCounter;
+
+/*
+ * pwmCounter goes over 64 a bit to limit the current of completely white
+ * board (0.5A) vs <0.3A for original firmware.
+ *
+ * You can get brighter LEDs if you set this to 64. And possibly burn the
+ * board in the longer period of time.
+ */
+const uint16_t pwmCounterLimit = 80;
+
+/* Disable timeouted LEDs */
+static inline void pwmRowDimmer() {
+  for (size_t ledRow = 0; ledRow < NUM_ROW * 3; ledRow++) {
+    const uint8_t time = rowTimes[ledRow];
+    if (pwmCounter == time) {
+      palClearLine(ledRows[ledRow]);
+      rowsEnabled--;
+    }
+  }
+  if (rowsEnabled == 0) {
+    /* Limit color bleed by disabling the column as early as possible */
+    palClearLine(ledColumns[currentColumn]);
+  }
+}
+
+/* Start new PWM cycle */
+static inline void pwmNextColumn() {
+  /* Disable previously lit column */
+  palClearLine(ledColumns[currentColumn]);
+
+  currentColumn = (currentColumn + 1) % NUM_COLUMN;
+
+  /* Prepare the PWM data and enable leds for non-zero colors */
+  rowsEnabled = 0;
+  for (size_t keyRow = 0; keyRow < NUM_ROW; keyRow++) {
+    const uint8_t ledIndex = ROWCOL2IDX(keyRow, currentColumn);
+    const led_t cl = ledColors[ledIndex];
+
+    for (size_t colorIdx = 0; colorIdx < 3; colorIdx++) {
+      const uint8_t ledRow = 3 * keyRow + colorIdx;
+      /* >>2 to decrease the color resolution from 0-255 to 0-63 */
+      uint8_t color = cl.pv[2 - colorIdx] >> 2;
+      if (color > 0) {
+        /* Each led is enabled for color>0 even for a short while. */
+        palSetLine(ledRows[ledRow]);
+        rowsEnabled++;
+      }
+      rowTimes[ledRow] = color;
+    }
+  }
+
+  /* Enable the current LED column if at least one row needs this. Limit bleed
+     and maybe power consumption on reactive profiles. */
+  if (rowsEnabled) {
+    palSetLine(ledColumns[currentColumn]);
+  }
+}
+
+/*
+ * Update lighting table as per animation
+ */
+static inline void animationCallback() {
+  // If the foreground is set we skip the animation as a way to avoid it
+  // overrides the foreground
+  if (foregroundColorSet) {
+    return;
+  }
+  profiles[currentProfile].callback(ledColors);
+}
+
+/*
+ * mainCallback is called by GPT timer periodically
+ * and is responsible for 2 things:
+ * - software PWM
+ * - calling animation callback for animated profiles
+ */
+void mainCallback(GPTDriver *_driver) {
+  (void)_driver;
+
+  pwmCounter += 1;
+  if (pwmCounter < pwmCounterLimit) {
+    pwmRowDimmer();
+    return;
+  }
+
+  /* Update profile if required before starting new cycle */
+  if (needToCallbackProfile) {
+    needToCallbackProfile = false;
+    profiles[currentProfile].callback(ledColors);
+  }
+
+  /* Animation can be updated after each full column cycle. On
+   * pwmCounterLimit=80 + 80kHz timer this refreshes at 80kHz/80/14 = 71Hz and
+   * should be a sensible maximum speed for a fluent smooth animation.
+   */
+  if (animationSkipTicks > 0 && currentColumn == 13) {
+    animationTicks++;
+    if (animationTicks >= animationSkipTicks) {
+      animationTicks = 0;
+      animationCallback();
+    }
+  }
+
+  /* We start a new PWM column cycle. */
+  pwmCounter = 0;
+
+  pwmNextColumn();
+}
+
+/*
+ * Turn off LEDs and PWM interrupt.
+ */
+void matrixDisable() {
+
+  chMtxLock(&mtx);
+
+  // stop timer, clock is still enabled
+  if (GPTD_BFTM0.state == GPT_CONTINUOUS) {
+    gptStopTimer(&GPTD_BFTM0);
+  }
+  // enter low power mode
+  if (GPTD_BFTM0.state == GPT_READY) {
+    gptStop(&GPTD_BFTM0);
+  }
+
+  palClearLine(LINE_LED_PWR);
+
+  for (int ledRow = 0; ledRow < NUM_ROW * 3; ledRow++) {
+    palClearLine(ledRows[ledRow]);
+  }
+  for (int i = 0; i < NUM_COLUMN; i++) {
+    palClearLine(ledColumns[i]);
+  }
+  chMtxUnlock(&mtx);
+}
+
+/*
+ * Turn on LED power and start PWM interrupt.
+ */
+void matrixEnable(void) {
+  chMtxLock(&mtx);
+
+  palSetLine(LINE_LED_PWR);
+
+  // start PWM handling interval
+  gptStart(&GPTD_BFTM0, &bftm0Config);
+  gptStartContinuous(&GPTD_BFTM0, 1);
+
+  chMtxUnlock(&mtx);
+}
+
+/* Initialize matrix module */
+void matrixInit() { chMtxObjectInit(&mtx); }

--- a/source/matrix.h
+++ b/source/matrix.h
@@ -1,0 +1,36 @@
+#ifndef MATRIX_INCLUDED
+#define MATRIX_INCLUDED
+
+#include "light_utils.h"
+
+/* PWM algorithm which controls the LED matrix */
+
+/* Calculate position within the ledColors array */
+#define ROWCOL2IDX(row, col) (NUM_COLUMN * (row) + (col))
+
+/* Current matrix state */
+extern led_t ledColors[KEY_COUNT];
+
+/* In case we switched to a new profile, the mainCallback should call the
+ * profile handler initially when this flag is set to true. */
+extern bool needToCallbackProfile;
+
+/* Animations */
+/* If non-zero the animation is enabled; 1 is full speed */
+extern volatile uint16_t animationSkipTicks;
+
+/* Animation tick counter used to slow down animations */
+extern uint16_t animationTicks;
+
+/* Forced colors by main chip */
+// Flag to check if there is a foreground color currently active
+extern bool foregroundColorSet;
+extern uint32_t foregroundColor;
+
+extern uint8_t ledMasks[KEY_COUNT];
+
+void matrixInit(void);
+void matrixEnable(void);
+void matrixDisable(void);
+
+#endif

--- a/source/miniFastLED.c
+++ b/source/miniFastLED.c
@@ -3,6 +3,7 @@
     This file contains functions adapted from the FastLED project (MIT License)
 */
 #include "miniFastLED.h"
+#include "settings.h"
 
 /*
     #define HSV specifics

--- a/source/profiles.c
+++ b/source/profiles.c
@@ -191,7 +191,7 @@ void reactiveFadeInit(led_t *ledColors) {
       animatedPressedBuf[i * NUM_COLUMN + j] = i * 15 + 25;
     }
   }
-  memset(ledColors, 0, NUM_ROW * NUM_COLUMN * 3);
+  memset(ledColors, 0, NUM_ROW * NUM_COLUMN * sizeof(*ledColors));
 }
 
 uint8_t pulseBuf[NUM_ROW];

--- a/source/profiles.h
+++ b/source/profiles.h
@@ -32,3 +32,7 @@ void reactiveFadeInit(led_t *ledColors);
 void reactivePulse(led_t *ledColors);
 void reactivePulseKeypress(led_t *ledColors, uint8_t row, uint8_t col);
 void reactivePulseInit(led_t *ledColors);
+
+void reactiveTerm(led_t *ledColors);
+void reactiveTermKeypress(led_t *ledColors, uint8_t row, uint8_t col);
+void reactiveTermInit(led_t *ledColors);

--- a/source/settings.c
+++ b/source/settings.c
@@ -1,0 +1,29 @@
+#include "settings.h"
+#include "profiles.h"
+
+/*
+ * Active profiles
+ * Add profiles from source/profiles.h in the profile array
+ */
+profile profiles[] = {
+    /* {colorBleed, {0, 0, 0, 0}, NULL, NULL}, */
+    {white, {0, 0, 0, 0}, NULL, NULL},
+    {red, {0, 0, 0, 0}, NULL, NULL},
+    {green, {0, 0, 0, 0}, NULL, NULL},
+    {blue, {0, 0, 0, 0}, NULL, NULL},
+    {rainbowHorizontal, {0, 0, 0, 0}, NULL, NULL},
+    {rainbowVertical, {0, 0, 0, 0}, NULL, NULL},
+    {animatedRainbowVertical, {35, 28, 21, 14}, NULL, NULL},
+    {animatedRainbowFlow, {7, 5, 2, 1}, NULL, NULL},
+    {animatedRainbowWaterfall, {7, 5, 2, 1}, NULL, NULL},
+    {animatedBreathing, {5, 3, 2, 1}, NULL, NULL},
+    {animatedWave, {5, 3, 2, 1}, NULL, NULL},
+    {animatedSpectrum, {11, 6, 4, 1}, NULL, NULL},
+    {reactiveFade, {4, 3, 2, 1}, reactiveFadeKeypress, reactiveFadeInit},
+    {reactivePulse, {4, 3, 2, 1}, reactivePulseKeypress, reactivePulseInit}};
+
+/* Set your defaults here */
+uint8_t currentProfile = 0;
+const uint8_t amountOfProfiles = sizeof(profiles) / sizeof(profile);
+volatile uint8_t currentSpeed = 0;
+uint8_t ledIntensity = 0;

--- a/source/settings.c
+++ b/source/settings.c
@@ -20,7 +20,8 @@ profile profiles[] = {
     {animatedWave, {5, 3, 2, 1}, NULL, NULL},
     {animatedSpectrum, {11, 6, 4, 1}, NULL, NULL},
     {reactiveFade, {4, 3, 2, 1}, reactiveFadeKeypress, reactiveFadeInit},
-    {reactivePulse, {4, 3, 2, 1}, reactivePulseKeypress, reactivePulseInit}};
+    {reactivePulse, {4, 3, 2, 1}, reactivePulseKeypress, reactivePulseInit},
+    {reactiveTerm, {1, 2, 3, 4}, reactiveTermKeypress, reactiveTermInit}};
 
 /* Set your defaults here */
 uint8_t currentProfile = 0;

--- a/source/settings.h
+++ b/source/settings.h
@@ -1,0 +1,44 @@
+#ifndef SETTINGS_INCLUDED
+#define SETTINGS_INCLUDED
+
+#include "light_utils.h"
+
+/*
+ * profile handlers
+ */
+typedef void (*keypress_handler)(led_t *colors, uint8_t row, uint8_t col);
+typedef void (*profile_init)(led_t *colors);
+typedef void (*lighting_callback)(led_t *);
+
+typedef struct {
+  // callback function implementing the lighting effect
+  lighting_callback callback;
+  // For static effects, their `callback` is called only once.
+  // For dynamic effects, their `callback` is called in a loop.
+  //
+  // This field controls the animation speed by specifying how many LED refresh
+  // cycles to skip before calling the callback again. For example, 1 in the
+  // array means that `callback` is called on every cycle, ie. ~71Hz on default
+  // settings.
+  //
+  // Different 4 values can be specified to allow different speeds of the same
+  // effect. For static effects, the array must contain {0, 0, 0, 0}.
+  uint16_t animationSpeed[4];
+  // In case the profile is reactive, it responds to each keypress.
+  // This callback is called with the locations of the pressed keys.
+  keypress_handler keypressCallback;
+  // Some profiles might need additional setup when just enabled.
+  // This callback defines such logic if needed.
+  profile_init profileInit;
+} profile;
+
+/* You can select your defaults in settings.c */
+extern profile profiles[];
+extern uint8_t currentProfile;
+extern const uint8_t amountOfProfiles;
+extern volatile uint8_t currentSpeed;
+
+/* Default zero corresponds to full intensity. */
+extern uint8_t ledIntensity;
+
+#endif


### PR DESCRIPTION
I did this changes a while back but run out of time shortly afterwards. This should be a simple refactor of a too big file into few smaller ones to simplify navigation. I was trying to build on it with HSV correct led dimming, but it's probably better to split things into smaller PRs. Pessimistically this will linger until I finish the HSV.

I've added additional commit with a reactive profile I wrote. If you don't want it (bloat?) I can remove this commit from the PR. IMHO there could be any number of profiles in the repo, but probably with #defines and compile-time enabled - it's even not that practical to cycle through all available profiles. They should be split into multiple files probalby too.
