### PR TITLE
A hue-correct HSV dimming for profiles and a naive RGB dimming.

### DIFF
--- a/source/miniFastLED.c
+++ b/source/miniFastLED.c
@@ -3,7 +3,6 @@
     This file contains functions adapted from the FastLED project (MIT License)
 */
 #include "miniFastLED.h"
-#include "settings.h"
 
 /*
     #define HSV specifics
@@ -15,33 +14,33 @@
 led_t rgbArray;
 
 // Convert HSV to RGB and write results to rgbResults
+// Applies current dimming settings.
 void hsv2rgb(uint8_t hue, uint8_t sat, uint8_t val, led_t *rgbResults) {
 
-  // Convert hue, saturation and brightness ( HSV/HSB ) to RGB
-  // "Dimming" is used on saturation and brightness to make
-  // the output more visually linear.
+  // Convert hue, saturation and brightness ( HSV/HSB ) to RGB while applying
+  // dimming to the HSV "Value".
 
   // Apply dimming curves
-  uint8_t value = val;
-  uint8_t saturation = sat;
+  const uint8_t value = dimValue(val);
+  const uint8_t saturation = sat;
 
   // The brightness floor is minimum number that all of
   // R, G, and B will be set to.
-  uint8_t invsat = 255 - saturation;
-  uint8_t brightness_floor = (value * invsat) / 256;
+  const uint8_t invsat = 255 - saturation;
+  const uint8_t brightness_floor = (value * invsat) / 256;
 
   // The color amplitude is the maximum amount of R, G, and B
   // that will be added on top of the brightness_floor to
   // create the specific hue desired.
-  uint8_t color_amplitude = value - brightness_floor;
+  const uint8_t color_amplitude = value - brightness_floor;
 
   // Figure out which section of the hue wheel we're in,
   // and how far offset we are withing that section
-  uint8_t section = hue / HSV_SECTION_3; // 0..2
-  uint8_t offset = hue % HSV_SECTION_3;  // 0..63
+  const uint8_t section = hue / HSV_SECTION_3; // 0..2
+  const uint8_t offset = hue % HSV_SECTION_3;  // 0..63
 
-  uint8_t rampup = offset;                         // 0..63
-  uint8_t rampdown = (HSV_SECTION_3 - 1) - offset; // 63..0
+  const uint8_t rampup = offset;                         // 0..63
+  const uint8_t rampdown = (HSV_SECTION_3 - 1) - offset; // 63..0
 
   // We now scale rampup and rampdown to a 0-255 range -- at least
   // in theory, but here's where architecture-specific decsions

--- a/source/miniFastLED.h
+++ b/source/miniFastLED.h
@@ -34,6 +34,45 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "board.h"
 #include "hal.h"
 #include "light_utils.h"
+#include "settings.h"
+
+/*
+    HSV Constants
+*/
+#define HUE_RED 0
+#define HUE_YELLOW 32
+#define HUE_GREEN 64
+#define HUE_CYAN 96
+#define HUE_BLUE 128
+#define HUE_MAGENTA 160
+
+/*
+    Helpers for dimming. There're used by hsv2rgb internally, but you can use
+    them if you're using direct RGB colors and want to dim them naively.
+ */
+
+/* Dim a single value: R, G, B or a saturation component of the HSV color */
+static inline int8_t dimValue(uint8_t value) {
+  const uint8_t dimBy = ledIntensity * 30;
+  if (dimBy > value)
+    return 0;
+  return value - dimBy;
+}
+
+/* Naively dim all values within the led_t variable */
+static inline void naiveDimLed(led_t *color) {
+  color->p.blue = dimValue(color->p.blue);
+  color->p.red = dimValue(color->p.red);
+  color->p.green = dimValue(color->p.green);
+}
+
+/* Returns a naively "dimmed" RGB color */
+static inline uint32_t naiveDimRGB(uint32_t color) {
+  led_t c;
+  c.rgb = color;
+  naiveDimLed(&c);
+  return c.rgb;
+}
 
 /*
     Function Signatures

--- a/source/profiles.c
+++ b/source/profiles.c
@@ -12,15 +12,15 @@ static const uint32_t colorPalette[] = {0xcc0000, 0xcccc00, 0x5fcc00, 0x00c7cc,
 #define LEN(a) (sizeof(a) / sizeof(*a))
 
 void red(led_t *currentKeyLedColors) {
-  setAllKeysColor(currentKeyLedColors, 0xFF0000);
+  setAllKeysColor(currentKeyLedColors, naiveDimRGB(0xFF0000));
 }
 
 void green(led_t *currentKeyLedColors) {
-  setAllKeysColor(currentKeyLedColors, 0x00FF00);
+  setAllKeysColor(currentKeyLedColors, naiveDimRGB(0x00FF00));
 }
 
 void blue(led_t *currentKeyLedColors) {
-  setAllKeysColor(currentKeyLedColors, 0x0000FF);
+  setAllKeysColor(currentKeyLedColors, naiveDimRGB(0x0000FF));
 }
 
 /* Color bleed test pattern */
@@ -59,19 +59,28 @@ void colorBleed(led_t *currentKeyLedColors) {
 }
 
 void white(led_t *currentKeyLedColors) {
-  /* To get "white" you need to compensate for red/blue switches on board */
-  setAllKeysColor(currentKeyLedColors, 0x80ff99);
+  /* To get "white" you need to compensate for red/blue switches on board.
+
+     This code also uses HSV instead of RGB to get the dimming of the white
+     color a bit better. Naive dimming (decreasing all components equally)
+     causes the mixed, unpure RGB colors to change hue.
+   */
+
+  // setAllKeysColor(currentKeyLedColors, 0x80ff99);
+  /* 80ff99 -> H63 S125 V255 */
+  setAllKeysColorHSV(currentKeyLedColors, 63, 125, 255);
 }
 
 void miamiNights(led_t *currentKeyLedColors) {
-  setAllKeysColor(currentKeyLedColors, 0x00979c);
-  setModKeysColor(currentKeyLedColors, 0x9c008f);
+  setAllKeysColor(currentKeyLedColors, naiveDimRGB(0x00979c));
+  setModKeysColor(currentKeyLedColors, naiveDimRGB(0x9c008f));
 }
 
 void rainbowHorizontal(led_t *currentKeyLedColors) {
   for (uint16_t i = 0; i < NUM_ROW; ++i) {
     for (uint16_t j = 0; j < NUM_COLUMN; ++j) {
-      setKeyColor(&currentKeyLedColors[i * NUM_COLUMN + j], colorPalette[i]);
+      setKeyColor(&currentKeyLedColors[i * NUM_COLUMN + j],
+                  naiveDimRGB(colorPalette[i]));
     }
   }
 }
@@ -80,7 +89,7 @@ void rainbowVertical(led_t *currentKeyLedColors) {
   for (uint16_t i = 0; i < NUM_COLUMN; ++i) {
     for (uint16_t j = 0; j < NUM_ROW; ++j) {
       setKeyColor(&currentKeyLedColors[j * NUM_COLUMN + i],
-                  colorPalette[i % LEN(colorPalette)]);
+                  naiveDimRGB(colorPalette[i % LEN(colorPalette)]));
     }
   }
 }
@@ -89,8 +98,9 @@ static uint8_t colAnimOffset = 0;
 void animatedRainbowVertical(led_t *currentKeyLedColors) {
   for (uint16_t i = 0; i < NUM_COLUMN; ++i) {
     for (uint16_t j = 0; j < NUM_ROW; ++j) {
-      setKeyColor(&currentKeyLedColors[j * NUM_COLUMN + i],
-                  colorPalette[(i + colAnimOffset) % LEN(colorPalette)]);
+      setKeyColor(
+          &currentKeyLedColors[j * NUM_COLUMN + i],
+          naiveDimRGB(colorPalette[(i + colAnimOffset) % LEN(colorPalette)]));
     }
   }
   colAnimOffset = (colAnimOffset + 1) % LEN(colorPalette);
@@ -259,6 +269,7 @@ void reactiveTerm(led_t *ledColors) {
 
   if (termPos < 0) {
     color.p.red = 255;
+    naiveDimLed(&color);
     lazyMark(ledColors, 0, -termPos, color);
     lazyMark(ledColors, 0, -termPos + 1, color);
     termPos += 2;
@@ -268,6 +279,7 @@ void reactiveTerm(led_t *ledColors) {
   if (rowBlink != -1) {
     color.p.red = 0;
     color.p.green = 255;
+    naiveDimLed(&color);
     for (int col = 0; col < NUM_COLUMN; col++) {
       lazyMark(ledColors, rowBlink, col, color);
     }
@@ -293,6 +305,7 @@ void reactiveTerm(led_t *ledColors) {
   }
   color.p.green = 0;
   color.p.red = brightness;
+  naiveDimLed(&color);
   lazyMark(ledColors, 0, termPos, color);
 }
 

--- a/source/settings.h
+++ b/source/settings.h
@@ -38,7 +38,7 @@ extern uint8_t currentProfile;
 extern const uint8_t amountOfProfiles;
 extern volatile uint8_t currentSpeed;
 
-/* Default zero corresponds to full intensity. */
+/* 0 - 7: Zero corresponds to the full intensity. */
 extern uint8_t ledIntensity;
 
 #endif


### PR DESCRIPTION
Color profiles can currently control how the dimming is done, either through
hsv2rgb, or directly on mostly pure RGB colors.

Not all work great when the board is highly dimmed and not for all profiles the
dimming makes sense at all.