### PR TITLE
Add light utility functions

### DIFF
--- a/source/light_utils.c
+++ b/source/light_utils.c
@@ -3,6 +3,7 @@
     This file contains functions useful for coding lighting profiles
 */
 #include "light_utils.h"
+#include "string.h"
 
 /*
     #define Directives declaration
@@ -27,6 +28,11 @@ static const uint8_t letterKeyIDs[] = {15, 16, 17, 18, 19, 20, 21, 22, 23,
 /*
     Function declarations
 */
+
+// Set all keys to blank
+void setAllKeysToBlank(led_t *ledColors) {
+  memset(ledColors, 0, NUM_COLUMN * NUM_ROW * sizeof(*ledColors));
+}
 
 // Set all keys lighting to a specific color
 void setAllKeysColor(led_t *ledColors, uint32_t color) {

--- a/source/light_utils.h
+++ b/source/light_utils.h
@@ -18,6 +18,7 @@ typedef union {
   uint32_t rgb;
 } led_t;
 
+void setAllKeysToBlank(led_t *ledColors);
 void setAllKeysColor(led_t *ledColors, uint32_t color);
 void setModKeysColor(led_t *ledColors, uint32_t color);
 void setLetterKeysColor(led_t *ledColors, uint32_t color);

--- a/source/profiles.c
+++ b/source/profiles.c
@@ -1,7 +1,6 @@
 #include "profiles.h"
 #include "matrix.h"
 #include "miniFastLED.h"
-#include "string.h"
 
 // An array of basic colors used accross different lighting profiles
 // static const uint32_t colorPalette[] = {0xFF0000, 0xF0F00, 0x00F00, 0x00F0F,
@@ -202,7 +201,7 @@ void reactiveFadeInit(led_t *ledColors) {
       animatedPressedBuf[i * NUM_COLUMN + j] = i * 15 + 25;
     }
   }
-  memset(ledColors, 0, NUM_ROW * NUM_COLUMN * sizeof(*ledColors));
+  setAllKeysToBlank(ledColors);
 }
 
 uint8_t pulseBuf[NUM_ROW];
@@ -242,7 +241,7 @@ void reactivePulseInit(led_t *ledColors) {
   for (int i = 0; i < NUM_ROW; i++) {
     pulseBuf[i] = 80 + i * 5;
   }
-  memset(ledColors, 0, NUM_ROW * NUM_COLUMN * 3);
+  setAllKeysToBlank(ledColors);
 }
 
 /*
@@ -265,7 +264,7 @@ uint16_t termAnim;
 void reactiveTerm(led_t *ledColors) {
   led_t color;
   color.rgb = 0;
-  memset(ledColors, 0, NUM_COLUMN * NUM_ROW * sizeof(*ledColors));
+  setAllKeysToBlank(ledColors);
 
   if (termPos < 0) {
     color.p.red = 255;
@@ -320,11 +319,11 @@ void reactiveTermKeypress(led_t *ledColors, uint8_t row, uint8_t col) {
   }
   termAnim = 0;
   rowBlink = row;
-  memset(ledColors, 0, NUM_COLUMN * NUM_ROW * sizeof(*ledColors));
+  setAllKeysToBlank(ledColors);
 }
 
 void reactiveTermInit(led_t *ledColors) {
   termPos = 0;
   termAnim = 0;
-  memset(ledColors, 0, NUM_COLUMN * NUM_ROW * sizeof(*ledColors));
+  setAllKeysToBlank(ledColors);
 }


### PR DESCRIPTION
My use case is:
```c
void cyan(led_t *currentKeyLedColors) {
  setAllKeysToBlank(currentKeyLedColors);
  setLetterKeysColor(currentKeyLedColors, naiveDimRGB(0x0195AF));
}
```
I am not sure about the need of adding an example as `miamiNights` uses `setModKeys` but is disabled.

#### Note
For completeness it could have:
- [1] numberKeys
- [2] numberKeys with - =
- [3] letterKeys with ,./;'[]\

But for what I see, people use more `2` and `3` (without `\`) and a `setModKeys` variation with `\`.

