### PR TITLE
Add commands for manual color control

### DIFF
--- a/source/matrix.c
+++ b/source/matrix.c
@@ -182,7 +182,7 @@ void mainCallback(GPTDriver *_driver) {
   }
 
   /* Update profile if required before starting new cycle */
-  if (needToCallbackProfile) {
+  if (!manualControl && needToCallbackProfile) {
     needToCallbackProfile = false;
     profiles[currentProfile].callback(ledColors);
   }
@@ -191,7 +191,7 @@ void mainCallback(GPTDriver *_driver) {
    * pwmCounterLimit=80 + 80kHz timer this refreshes at 80kHz/80/14 = 71Hz and
    * should be a sensible maximum speed for a fluent smooth animation.
    */
-  if (animationSkipTicks > 0 && currentColumn == 13) {
+  if (!manualControl && animationSkipTicks > 0 && currentColumn == 13) {
     animationTicks++;
     if (animationTicks >= animationSkipTicks) {
       animationTicks = 0;

--- a/source/protocol.h
+++ b/source/protocol.h
@@ -43,6 +43,12 @@ enum {
   CMD_LED_KEY_UP = 0x23, /* TODO */
   CMD_LED_IAP = 0x24,
 
+  /* Manual color control */
+  CMD_LED_SET_MANUAL = 0x30,
+  CMD_LED_COLOR_SET_KEY = 0x31,
+  CMD_LED_COLOR_SET_ROW = 0x32,
+  CMD_LED_COLOR_SET_MONO = 0x33,
+
   /* LED -> Main */
   /* Payload with data to send over HID */
   CMD_LED_DEBUG = 0x40,

--- a/source/settings.c
+++ b/source/settings.c
@@ -27,6 +27,7 @@ profile profiles[] = {
 uint8_t currentProfile = 0;
 const uint8_t amountOfProfiles = sizeof(profiles) / sizeof(profile);
 volatile uint8_t currentSpeed = 0;
+uint8_t manualControl = 0;
 uint8_t ledIntensity = 0;
 led_t color_correction = (led_t){.rgb = 0x80FF99};
 led_t color_temperature = (led_t){.rgb = 0xFFFFFF};

--- a/source/settings.h
+++ b/source/settings.h
@@ -38,6 +38,9 @@ extern uint8_t currentProfile;
 extern const uint8_t amountOfProfiles;
 extern volatile uint8_t currentSpeed;
 
+/* Whether ledColors should be updated in mainCallback in matrix.c */
+extern uint8_t manualControl;
+
 /* 0 - 7: Zero corresponds to the full intensity. */
 extern uint8_t ledIntensity;
 


### PR DESCRIPTION
I've added commands to manually control ledColors. I think this can be very useful for the upstream QMK firmware's RGB controls. Currently they rely on setting color through mask, this works but doesn't allow usage of mask for what it's actually meant to be used for (e.g. indication of layer/caps lock/...). With this added functionality the firmware can control colors directly and users can use mask as intended.