### PR TITLE
Add sticky keys

### DIFF
--- a/source/matrix.h
+++ b/source/matrix.h
@@ -14,6 +14,9 @@ extern led_t ledColors[KEY_COUNT];
 /* Color override by main chip. */
 extern led_t ledMask[KEY_COUNT];
 
+/* Color override by main chip that stays on even after LED_OFF. */
+extern led_t ledSticky[KEY_COUNT];
+
 /* In case we switched to a new profile, the mainCallback should call the
  * profile handler initially when this flag is set to true. */
 extern bool needToCallbackProfile;

--- a/source/protocol.h
+++ b/source/protocol.h
@@ -56,6 +56,15 @@ enum {
   /* Number of profiles, current profile, on/off state,
      reactive flag, brightness, errors */
   CMD_LED_STATUS = 0x41,
+
+  /* Set sticky key, meaning the key will light up even when LEDs are turned off
+   */
+  CMD_LED_STICKY_SET_KEY = 0x50,
+  CMD_LED_STICKY_SET_ROW = 0x51,
+  CMD_LED_STICKY_SET_MONO = 0x52,
+  CMD_LED_STICKY_UNSET_KEY = 0x53,
+  CMD_LED_STICKY_UNSET_ROW = 0x54,
+  CMD_LED_STICKY_UNSET_ALL = 0x55,
 };
 
 /* 1 ROW * 14 COLS * 4B (RGBX) = 56 + header prefix. */

--- a/source/settings.c
+++ b/source/settings.c
@@ -28,6 +28,8 @@ uint8_t currentProfile = 0;
 const uint8_t amountOfProfiles = sizeof(profiles) / sizeof(profile);
 volatile uint8_t currentSpeed = 0;
 uint8_t manualControl = 0;
+uint8_t backlightDisabled = 0;
+uint8_t stickyKeysExist = 0;
 uint8_t ledIntensity = 0;
 led_t color_correction = (led_t){.rgb = 0x80FF99};
 led_t color_temperature = (led_t){.rgb = 0xFFFFFF};

--- a/source/settings.h
+++ b/source/settings.h
@@ -41,6 +41,10 @@ extern volatile uint8_t currentSpeed;
 /* Whether ledColors should be updated in mainCallback in matrix.c */
 extern uint8_t manualControl;
 
+/* Wheter we should disable keyboard after all sticky keys are unset */
+extern uint8_t backlightDisabled;
+extern uint8_t stickyKeysExist;
+
 /* 0 - 7: Zero corresponds to the full intensity. */
 extern uint8_t ledIntensity;
 


### PR DESCRIPTION
I think it would be useful to have the ability to keep certain LEDs shining even after user calls `matrixDisable` (e.g. to indicate capslock being active or current active layer). I've named this functionality `stickyKeys` because the keys' lights stick around even after you turn off the backlight.

I've been using this version of shine for about a week and as far as I can tell everything works fine.