### PR TITLE
Report isReactive as false when manual control enabled

### DIFF
--- a/source/commands.c
+++ b/source/commands.c
@@ -14,7 +14,9 @@
  * keys should be sent to LED controller.
  */
 static inline void sendStatus(void) {
-  uint8_t isReactive = profiles[currentProfile].keypressCallback != NULL;
+  uint8_t isReactive = profiles[currentProfile].keypressCallback != NULL &&
+    !manualControl &&
+    !backlightDisabled;
 
   uint8_t payload[] = {
       amountOfProfiles, currentProfile, matrixEnabled,
@@ -343,6 +345,7 @@ void commandCallback(const message_t *msg) {
   /* Handle manual color control */
   case CMD_LED_SET_MANUAL:
     setManual(msg);
+    sendStatus();
     break;
   case CMD_LED_COLOR_SET_KEY:
     setColorKey(msg);


### PR DESCRIPTION
This PR updates `is_reactive` status value to be false when manual control is enabled or backlight is disabled.

Current logic in [QMK](https://github.com/qmk/qmk_firmware/blob/319d9aa7b94daba050a7d207caf2dd607b04298c/keyboards/annepro2/annepro2.c#L131) forwards info on keypresses if rgb matrix is enabled and `is_reactive` is true.

If the user has enabled a Shine reactive profile + changed to QMK matrix using manual control, QMK firmware will still forward the keypress info even though it is not used.

Another potential improvement is when the backlight is disabled and reactive profile enabled, this stops QMK forwarding redundant keypress info.